### PR TITLE
Fix hang erasure encoding data in HDFS and another assertion bug

### DIFF
--- a/src/proto/hdfs.proto
+++ b/src/proto/hdfs.proto
@@ -159,6 +159,46 @@ message DataEncryptionKeyProto {
   optional string encryptionAlgorithm = 6;
 }
 
+/**
+ * ECSchema options entry
+ */
+message ECSchemaOptionEntryProto {
+  required string key = 1;
+  required string value = 2;
+}
+
+/**
+ * ECSchema for erasurecoding
+ */
+message ECSchemaProto {
+  required string codecName = 1;
+  required uint32 dataUnits = 2;
+  required uint32 parityUnits = 3;
+  repeated ECSchemaOptionEntryProto options = 4;
+}
+
+/**
+ * EC policy state.
+ */
+enum ErasureCodingPolicyState {
+  DISABLED = 1;
+  ENABLED = 2;
+  REMOVED = 3;
+}
+
+message ErasureCodingPolicyProto {
+  optional string name = 1;
+  optional ECSchemaProto schema = 2;
+  optional uint32 cellSize = 3;
+  required uint32 id = 4; // Actually a byte - only 8 bits used
+  optional ErasureCodingPolicyState state = 5 [default = ENABLED];
+}
+
+message AddErasureCodingPolicyResponseProto {
+  required ErasureCodingPolicyProto policy = 1;
+  required bool succeed = 2;
+  optional string errorMsg = 3;
+}
 
 /**
  * A set of file blocks and their locations.
@@ -169,6 +209,9 @@ message LocatedBlocksProto {
   required bool underConstruction = 3;
   optional LocatedBlockProto lastBlock = 4;
   required bool isLastBlockComplete = 5;
+
+    // Optional field for erasure coding
+  optional ErasureCodingPolicyProto ecPolicy = 7;
 }
 
 

--- a/src/server/RpcHelper.h
+++ b/src/server/RpcHelper.h
@@ -137,12 +137,12 @@ static inline shared_ptr<LocatedBlock> Convert(const LocatedBlockProto & proto) 
         Convert(nodes[i], proto.locs(i));
     }
 
-    if (proto.storagetypes_size() > 0) {
-        assert(proto.storagetypes_size() == proto.locs_size());
+    if (proto.storageids_size() > 0) {
+        assert(proto.storageids_size() == proto.locs_size());
         std::vector<std::string> & storageIDs = lb->mutableStorageIDs();
-        storageIDs.resize(proto.storagetypes_size());
+        storageIDs.resize(proto.storageids_size());
 
-        for (int i = 0; i < proto.storagetypes_size(); ++i) {
+        for (int i = 0; i < proto.storageids_size(); ++i) {
             storageIDs[i] = proto.storageids(i);
         }
     }

--- a/src/server/RpcHelper.h
+++ b/src/server/RpcHelper.h
@@ -137,12 +137,12 @@ static inline shared_ptr<LocatedBlock> Convert(const LocatedBlockProto & proto) 
         Convert(nodes[i], proto.locs(i));
     }
 
-    if (proto.storageids_size() > 0) {
-        assert(proto.storageids_size() == proto.locs_size());
+    if (proto.storagetypes_size() > 0) {
+        assert(proto.storagetypes_size() == proto.locs_size());
         std::vector<std::string> & storageIDs = lb->mutableStorageIDs();
-        storageIDs.resize(proto.storageids_size());
+        storageIDs.resize(proto.storagetypes_size());
 
-        for (int i = 0; i < proto.storageids_size(); ++i) {
+        for (int i = 0; i < proto.storagetypes_size(); ++i) {
             storageIDs[i] = proto.storageids(i);
         }
     }
@@ -155,6 +155,8 @@ static inline shared_ptr<LocatedBlock> Convert(const LocatedBlockProto & proto) 
 
 static inline void Convert(LocatedBlocks & lbs,
                            const LocatedBlocksProto & proto) {
+    if (proto.has_ecpolicy())
+        THROW(HdfsIOException, "EC policy is not supported");
     shared_ptr<LocatedBlock> lb;
     lbs.setFileLength(proto.filelength());
     lbs.setIsLastBlockComplete(proto.islastblockcomplete());


### PR DESCRIPTION
Two changes:
1) Now libhdfs3 does not support erasure encoding data in HDFS, causing clickhouse hangs. We just throw "not supported" hint for now, and we will develop libhdfs3 to support EC in later days.
<img width="803" alt="image" src="https://user-images.githubusercontent.com/985418/168709300-972bee69-0084-49b7-8608-ae8e28790531.png">

2) Fix another assertion fail in debug mode.
According this https://github.com/apache/hadoop/blob/62c86eaa0e539a4307ca794e0fcd502a77ebceb8/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/PBHelperClient.java#L641
https://github.com/apache/hadoop/blob/62c86eaa0e539a4307ca794e0fcd502a77ebceb8/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/PBHelperClient.java#L800
stack:
![image](https://user-images.githubusercontent.com/985418/168709569-1239915b-b0aa-4901-a2de-9085ed677dbc.png)
