### PR TITLE
support secure datanode data transfer

### DIFF
--- a/src/client/DataReader.cpp
+++ b/src/client/DataReader.cpp
@@ -1,0 +1,270 @@
+/********************************************************************
+ * Copyright (c) 2013 - 2014, Pivotal Inc.
+ * All rights reserved.
+ *
+ * Author: Zhanwei Wang
+ ********************************************************************/
+/********************************************************************
+ * 2014 -
+ * open source under Apache License Version 2.0
+ ********************************************************************/
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "DateTime.h"
+#include "Pipeline.h"
+#include "Logger.h"
+#include "Exception.h"
+#include "ExceptionInternal.h"
+#include "datatransfer.pb.h"
+#include "DataReader.h"
+
+
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+
+using namespace ::google::protobuf;
+using namespace google::protobuf::io;
+
+namespace Hdfs {
+namespace Internal {
+
+
+int fillData(BufferedSocketReader *reader, std::string &raw, bool &error, DataTransferProtocol *sender=NULL) {
+    int offset=0;
+    int numRetries=0;
+    raw.resize(65536);
+    int polltime = 100;
+    error = false;
+    if (sender) {
+        std::string temp;
+        temp.resize(1);
+
+        // we need to read at most 5 bytes
+        int i = 0;
+        std::string data;
+        while (i < 5) {
+            reader->readFully(&temp[0], 1, 30000);
+            std::string dec = sender->unwrap(temp);
+            i += 1;
+            data += dec;
+            const uint8* ptr = (uint8*) dec.c_str();
+            if (!(*ptr & 0x80))
+                break;
+        }
+        CodedInputStream stream(reinterpret_cast<const uint8_t *>(data.c_str()), data.length());
+        int size;
+        bool ret = stream.ReadVarint32((uint32*)&size);
+        if (!ret || size <= 0 || size > 65536)
+        {
+            // Not encrypted error case
+            memcpy(&raw[0], &temp[0], 5);
+            offset = 5;
+            error = true;
+        } else {
+
+            // This is the logic used by ReadVarint32. Unfortunately
+            // the class does not give a way to tell how data was consumed.
+            const uint8* ptr = (uint8*) data.c_str();
+            int used = 1;
+            for (int i=0; i < (int)data.size(); i++) {
+                if (!(*ptr & 0x80))
+                    break;
+                used += 1;
+                ptr += 1;
+            }
+            int remaining = data.length() - used;
+            if (size - remaining) {
+                temp.resize(size-remaining);
+                reader->readFully(&temp[0], size-remaining, 30000);
+                data = data + sender->unwrap(temp);
+            }
+            raw.assign(data);
+            return data.length();
+        }
+    }
+
+    while (numRetries < 5 && offset < 65536) {
+        if (reader->poll(polltime)) {
+            int nread = 0;
+
+            try {
+                nread = reader->read(&raw[offset], 65536-offset);
+            }
+            catch (HdfsEndOfStream ex) {
+                if (offset == 0)
+                    throw;
+                break;
+            }
+            catch (HdfsNetworkException ex) {
+                if (offset == 0)
+                    throw;
+                error = true;
+                break;
+            }
+            if (nread) {
+                offset += nread;
+                numRetries = 0;
+            } else {
+                numRetries += 1;
+            }
+            if (offset > 10)
+                polltime = 30;
+        } else {
+            numRetries += 1;
+        }
+    }
+    if (offset == 0) {
+        THROW(HdfsIOException, "Couldn't fill buffer")
+    }
+    raw.resize(offset);
+    return offset;
+
+}
+DataReader::DataReader(DataTransferProtocol * sender,
+        shared_ptr<BufferedSocketReader> reader, int readTimeout) : buf(128), sender(sender),
+        reader(reader), readTimeout(readTimeout)
+        {
+            // max size of packet
+            raw.resize(65536);
+            decrypted.resize(65536);
+        }
+
+std::vector<char>& DataReader::readPacketHeader(const char* text, int size, int &outsize) {
+    int nread = size;
+    if (rest.size()) {
+        decrypted = rest;
+        rest = "";
+        if ((int)decrypted.size() < size) {
+            bool error = false;
+            fillData(reader.get(), raw, error);
+            decrypted += sender->unwrap(raw);
+        }
+    } else {
+        bool error = false;
+        fillData(reader.get(), raw, error);
+        if (!error)
+            decrypted = sender->unwrap(raw);
+        else
+            decrypted = raw;
+    }
+    CodedInputStream stream(reinterpret_cast<const uint8_t *>(decrypted.c_str()), decrypted.length());
+    buf.resize(nread);
+    bool ret = stream.ReadRaw(&buf[0], nread);
+    if (!ret) {
+        THROW(HdfsIOException, "cannot parse wrapped datanode data response: %s",
+          text);
+    }
+    rest.assign(&decrypted[nread], decrypted.size()-nread);
+    outsize = nread;
+    return buf;
+}
+
+void DataReader::setRest(const char* data, int size) {
+    rest.assign(data, size);
+}
+
+void DataReader::getMissing(int size) {
+    bool error = false;
+    if (sender->isWrapped()) {
+        if (!sender->needsLength()) {
+            while (size > (int)rest.size()) {
+                fillData(reader.get(), raw, error);
+                decrypted = sender->unwrap(raw);
+                rest = rest + decrypted;
+            }
+        }
+     }
+}
+
+void DataReader::reduceRest(int size) {
+    std::string temp;
+    temp.assign(rest.c_str() + size, rest.size()-size);
+    rest = temp;
+}
+
+std::vector<char>& DataReader::readResponse(const char* text, int &outsize) {
+    int size;
+    bool error = false;
+    if (sender->isWrapped()) {
+        if (!sender->needsLength()) {
+            if (rest.size()) {
+                decrypted = rest;
+                rest = "";
+            } else {
+                fillData(reader.get(), raw, error, sender);
+                decrypted = raw;
+            }
+            CodedInputStream stream(reinterpret_cast<const uint8_t *>(decrypted.c_str()), decrypted.length());
+            bool ret = stream.ReadVarint32((uint32*)&size);
+
+            if (!ret) {
+                THROW(HdfsIOException, "cannot parse wrapped datanode size response: %s",
+                  text);
+            }
+            if ((int)decrypted.size() < size) {
+                fillData(reader.get(), raw, error);
+                decrypted += sender->unwrap(raw);
+            }
+            buf.resize(size);
+            ret = stream.ReadRaw(&buf[0], size);
+            if (!ret) {
+                THROW(HdfsIOException, "cannot parse wrapped datanode data response: %s",
+                  text);
+            }
+            int pos = decrypted.find(&buf[0], 0, size);
+            if (pos == (int)string::npos) {
+                THROW(HdfsIOException, "cannot parse wrapped datanode data response: %s",
+                  text);
+            }
+
+            rest.assign(&decrypted[size+pos], decrypted.size()-(size+pos));
+        } else {
+            size = reader->readBigEndianInt32(readTimeout);
+            buf.resize(size);
+            reader->readFully(&buf[0], size, readTimeout);
+
+            std::string data = sender->unwrap(&buf[0], size);
+
+            bool ret;
+            CodedInputStream stream(reinterpret_cast<const uint8_t *>(data.c_str()), data.length());
+            ret = stream.ReadVarint32((uint32*)&size);
+            if (!ret) {
+                THROW(HdfsIOException, "cannot parse wrapped datanode size response: %s",
+                  text);
+            }
+            buf.resize(size);
+            ret = stream.ReadRaw(&buf[0], size);
+            if (!ret) {
+                THROW(HdfsIOException, "cannot parse wrapped datanode data response: %s",
+                  text);
+            }
+       }
+    }
+    else {
+        size = reader->readVarint32(readTimeout);
+        buf.resize(size);
+        reader->readFully(&buf[0], size, readTimeout);
+    }
+    outsize = size;
+    return buf;
+}
+
+
+}
+}

--- a/src/client/DataReader.h
+++ b/src/client/DataReader.h
@@ -25,22 +25,42 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "RpcConfig.h"
+#ifndef _HDFS_LIBHDFS3_SERVER_DATAREADER_H_
+#define _HDFS_LIBHDFS3_SERVER_DATAREADER_H_
 
+#include <string>
 #include <vector>
-
 namespace Hdfs {
 namespace Internal {
 
-size_t RpcConfig::hash_value() const {
-    size_t values[] = { Int32Hasher(maxIdleTime), Int32Hasher(pingTimeout),
-                        Int32Hasher(connectTimeout), Int32Hasher(readTimeout), Int32Hasher(
-                            writeTimeout), Int32Hasher(maxRetryOnConnect), Int32Hasher(
-                            lingerTimeout), Int32Hasher(rpcTimeout), BoolHasher(tcpNoDelay),
-                            Int32Hasher(protection)
-                      };
-    return CombineHasher(values, sizeof(values) / sizeof(values[0]));
-}
+/**
+ * Helps read data responses from the server
+ */
+class DataReader {
+public:
+    DataReader(DataTransferProtocol *sender,
+            shared_ptr<BufferedSocketReader> reader, int readTimeout);
+    std::vector<char>& readResponse(const char* text, int &outsize);
+    std::vector<char>& readPacketHeader(const char* text, int size, int &outsize);
+    std::string& getRest() {
+        return rest;
+    }
+
+    void setRest(const char* data, int size);
+    void reduceRest(int size);
+    void getMissing(int size);
+
+private:
+    std::string raw;
+    std::string decrypted;
+    std::string rest;
+    std::vector<char> buf;
+    DataTransferProtocol *sender;
+    shared_ptr<BufferedSocketReader> reader;
+    int readTimeout;
+};
 
 }
 }
+
+#endif /* _HDFS_LIBHDFS3_SERVER_DATAREADER_H_ */

--- a/src/client/DataTransferProtocol.h
+++ b/src/client/DataTransferProtocol.h
@@ -115,6 +115,13 @@ public:
     virtual void requestShortCircuitFds(const ExtendedBlock blk,
                                         const Token& blockToken,
                                         uint32_t maxVersion) = 0;
+
+    virtual bool needsLength() = 0;
+    virtual bool isWrapped() = 0;
+    virtual std::string unwrap(std::string &data) = 0;
+    virtual std::string wrap(std::string &data) = 0;
+    virtual std::string unwrap(const char *input, size_t input_len) = 0;
+    virtual std::string wrap(const char *input, size_t input_len) = 0;
 };
 
 }

--- a/src/client/DataTransferProtocolSender.cpp
+++ b/src/client/DataTransferProtocolSender.cpp
@@ -33,6 +33,8 @@
 #include "hdfs.pb.h"
 #include "Security.pb.h"
 #include "WriteBuffer.h"
+#include "network/BufferedSocketReader.h"
+
 
 using namespace google::protobuf;
 
@@ -40,7 +42,7 @@ namespace Hdfs {
 namespace Internal {
 
 static inline void Send(Socket & sock, DataTransferOp op, Message * msg,
-                        int writeTimeout) {
+                        int writeTimeout, SaslClient *saslClient) {
     WriteBuffer buffer;
     buffer.writeBigEndian(static_cast<int16_t>(DATA_TRANSFER_VERSION));
     buffer.write(static_cast<char>(op));
@@ -52,8 +54,24 @@ static inline void Send(Socket & sock, DataTransferOp op, Message * msg,
         THROW(HdfsIOException,
               "DataTransferProtocolSender cannot serialize header to send buffer.");
     }
-
-    sock.writeFully(buffer.getBuffer(0), buffer.getDataSize(0), writeTimeout);
+    std::string rawdata;
+    if (saslClient) {
+        std::string data = saslClient->encode(buffer.getBuffer(0), buffer.getDataSize(0));
+        WriteBuffer buffer2;
+        if (saslClient->needsLength())
+            buffer2.writeBigEndian(static_cast<int32_t>(data.length()));
+        char * b = buffer2.alloc(data.length());
+        memcpy(b, data.c_str(), data.length());
+        int size = buffer2.getDataSize(0);
+        rawdata.resize(size);
+        memcpy(rawdata.data(), buffer2.getBuffer(0), size);
+    }
+    else {
+        int size = buffer.getDataSize(0);
+        rawdata.resize(size);
+        memcpy(rawdata.data(), buffer.getBuffer(0), size);
+    }
+    sock.writeFully(rawdata.c_str(), rawdata.length(), writeTimeout);
 }
 
 static inline void BuildBaseHeader(const ExtendedBlock & block,
@@ -97,11 +115,16 @@ static inline void BuildNodesInfo(const std::vector<DatanodeInfo> & nodes,
 }
 
 DataTransferProtocolSender::DataTransferProtocolSender(Socket & sock,
-        int writeTimeout, const std::string & datanodeAddr) :
-    sock(sock), writeTimeout(writeTimeout), datanode(datanodeAddr) {
+        int writeTimeout, const std::string & datanodeAddr, bool secure, bool token,
+        EncryptionKey& key, int32_t cryptoBufferSize, int32_t protection) :
+    sock(sock), writeTimeout(writeTimeout), datanode(datanodeAddr), isSecure(secure),
+    isToken(token), saslComplete(false), saslClient(NULL), theKey(key), cryptoBufferSize(cryptoBufferSize),
+     protection(protection){
 }
 
 DataTransferProtocolSender::~DataTransferProtocolSender() {
+    if (saslClient)
+        delete saslClient;
 }
 
 void DataTransferProtocolSender::readBlock(const ExtendedBlock & blk,
@@ -112,9 +135,19 @@ void DataTransferProtocolSender::readBlock(const ExtendedBlock & blk,
         op.set_len(length);
         op.set_offset(blockOffset);
         BuildClientHeader(blk, blockToken, clientName, op.mutable_header());
-        Send(sock, READ_BLOCK, &op, writeTimeout);
+        if (isSecure || isToken)
+            setupSasl(blk, blockToken);
+        Send(sock, READ_BLOCK, &op, writeTimeout, saslClient);
     } catch (const HdfsCanceled & e) {
         throw;
+    } catch (const HdfsEndOfStream & e) {
+        NESTED_THROW(HdfsEndOfStream,
+                     "DataTransferProtocolSender cannot send write request to datanode %s.",
+                     datanode.c_str());
+    } catch (const HdfsIOException & e) {
+        NESTED_THROW(HdfsIOException,
+                     "DataTransferProtocolSender cannot send write request to datanode %s.",
+                     datanode.c_str());
     } catch (const HdfsException & e) {
         NESTED_THROW(HdfsIOException,
                      "DataTransferProtocolSender cannot send read request to datanode %s.",
@@ -139,9 +172,19 @@ void DataTransferProtocolSender::writeBlock(const ExtendedBlock & blk,
         ck->set_bytesperchecksum(bytesPerChecksum);
         ck->set_type((ChecksumTypeProto) checksumType);
         BuildNodesInfo(targets, op.mutable_targets());
-        Send(sock, WRITE_BLOCK, &op, writeTimeout);
+        if (isSecure || isToken)
+            setupSasl(blk, blockToken);
+        Send(sock, WRITE_BLOCK, &op, writeTimeout, saslClient);
     } catch (const HdfsCanceled & e) {
         throw;
+    } catch (const HdfsEndOfStream & e) {
+        NESTED_THROW(HdfsEndOfStream,
+                     "DataTransferProtocolSender cannot send write request to datanode %s.",
+                     datanode.c_str());
+    } catch (const HdfsIOException & e) {
+        NESTED_THROW(HdfsIOException,
+                     "DataTransferProtocolSender cannot send write request to datanode %s.",
+                     datanode.c_str());
     } catch (const HdfsException & e) {
         NESTED_THROW(HdfsIOException,
                      "DataTransferProtocolSender cannot send write request to datanode %s.",
@@ -156,9 +199,19 @@ void DataTransferProtocolSender::transferBlock(const ExtendedBlock & blk,
         OpTransferBlockProto op;
         BuildClientHeader(blk, blockToken, clientName, op.mutable_header());
         BuildNodesInfo(targets, op.mutable_targets());
-        Send(sock, TRANSFER_BLOCK, &op, writeTimeout);
+        if (isSecure || isToken)
+            setupSasl(blk, blockToken);
+        Send(sock, TRANSFER_BLOCK, &op, writeTimeout, saslClient);
     } catch (const HdfsCanceled & e) {
         throw;
+    } catch (const HdfsEndOfStream & e) {
+        NESTED_THROW(HdfsEndOfStream,
+                     "DataTransferProtocolSender cannot send transfer request to datanode %s.",
+                     datanode.c_str());
+    } catch (const HdfsIOException & e) {
+        NESTED_THROW(HdfsIOException,
+                     "DataTransferProtocolSender cannot send transfer request to datanode %s.",
+                     datanode.c_str());
     } catch (const HdfsException & e) {
         NESTED_THROW(HdfsIOException,
                      "DataTransferProtocolSender cannot send transfer request to datanode %s.",
@@ -186,10 +239,20 @@ void DataTransferProtocolSender::requestShortCircuitFds(const ExtendedBlock blk,
         OpRequestShortCircuitAccessProto op;
         BuildBaseHeader(blk, blockToken, op.mutable_header());
         op.set_maxversion(maxVersion);
+        if (isSecure || isToken)
+            setupSasl(blk, blockToken);
 
-        Send(sock, REQUEST_SHORT_CIRCUIT_FDS, &op, writeTimeout);
+        Send(sock, REQUEST_SHORT_CIRCUIT_FDS, &op, writeTimeout, saslClient);
     } catch (const HdfsCanceled& e) {
         throw;
+    } catch (const HdfsEndOfStream & e) {
+        NESTED_THROW(HdfsEndOfStream,
+                     "DataTransferProtocolSender cannot send short-circuit fds request to datanode %s.",
+                     datanode.c_str());
+     } catch (const HdfsIOException & e) {
+        NESTED_THROW(HdfsIOException,
+                     "DataTransferProtocolSender cannot send short-circuit fds request to datanode %s.",
+                     datanode.c_str());
     } catch (const HdfsException& e) {
         NESTED_THROW(HdfsIOException,
                      "DataTransferProtocolSender cannot send request "
@@ -197,6 +260,172 @@ void DataTransferProtocolSender::requestShortCircuitFds(const ExtendedBlock blk,
                      "to datanode %s.",
                      datanode.c_str());
     }
+}
+
+void sendSaslMessage(Socket & sock, DataTransferEncryptorMessageProto_DataTransferEncryptorStatus status,
+    std::string payload, std::string message, int writeTimeout, bool secure) {
+    DataTransferEncryptorMessageProto msg;
+
+    msg.set_status(status);
+    msg.set_payload(payload.c_str());
+    msg.set_message(message);
+
+    if (secure) {
+        CipherOptionProto* added = msg.add_cipheroption();
+        added->set_suite(CipherSuiteProto::AES_CTR_NOPADDING);
+    }
+    WriteBuffer buffer;
+    int msgSize = msg.ByteSize();
+    buffer.writeVarint32(msgSize);
+    char * b = buffer.alloc(msgSize);
+
+    if (!msg.SerializeToArray(b, msgSize)) {
+        THROW(HdfsIOException,
+              "DataTransferProtocolSender cannot serialize SASL message to send buffer.");
+    }
+
+    sock.writeFully(buffer.getBuffer(0), buffer.getDataSize(0), writeTimeout);
+
+
+}
+
+void readSaslMessage(Socket & sock, int readTimeout, DataTransferEncryptorMessageProto &msg,
+                        std::string &datanode) {
+    std::vector<char> buffer(128);
+    std::vector<char> body(128);
+    uint32_t headerSize = 0;
+    /*
+     * read response header
+     */
+    BufferedSocketReaderImpl in(sock);
+
+    headerSize = in.readVarint32(readTimeout);
+    buffer.resize(headerSize);
+    in.readFully(&buffer[0], headerSize, readTimeout);
+
+    if (!msg.ParseFromArray(buffer.data(), headerSize)) {
+        THROW(HdfsRpcException,
+              "DataNode to \"%s\" got protocol mismatch: cannot parse response header.",
+              datanode.c_str())
+    }
+    if (msg.status() != DataTransferEncryptorMessageProto_DataTransferEncryptorStatus_SUCCESS) {
+        THROW(HdfsRpcException,
+              "DataNode to \"%s\" got protocol mismatch: got error reading SASL response: %s.",
+              datanode.c_str(), msg.message().c_str())
+    }
+}
+
+bool DataTransferProtocolSender::isWrapped() {
+    if (saslClient && (saslClient->isPrivate() || saslClient->isIntegrity()))
+        return true;
+    return false;
+}
+
+bool DataTransferProtocolSender::needsLength() {
+    if (saslClient)
+        return saslClient->needsLength();
+    return true;
+}
+
+std::string DataTransferProtocolSender::unwrap(std::string& data) {
+    std::string rawdata = saslClient->decode(data.c_str(), data.length());
+    return rawdata;
+}
+
+std::string DataTransferProtocolSender::wrap(std::string& data) {
+    std::string rawdata = saslClient->encode(data.c_str(), data.length());
+    return rawdata;
+}
+
+std::string DataTransferProtocolSender::unwrap(const char *input, size_t input_len) {
+    std::string rawdata = saslClient->decode(input, input_len);
+    return rawdata;
+}
+
+std::string DataTransferProtocolSender::wrap(const char *input, size_t input_len) {
+    std::string rawdata = saslClient->encode(input, input_len);
+    return rawdata;
+}
+
+extern std::string Base64Encode(const std::string & in);
+
+void DataTransferProtocolSender::setupSasl(const ExtendedBlock blk, const Token& blockToken) {
+    WriteBuffer buffer;
+    buffer.writeBigEndian((int)0xDEADBEEF);
+
+    sock.writeFully(buffer.getBuffer(0), buffer.getDataSize(0), writeTimeout);
+    std::string payload;
+    payload.resize(1);
+    payload[0] = 0;
+
+    sendSaslMessage(sock, DataTransferEncryptorMessageProto_DataTransferEncryptorStatus_SUCCESS,
+        payload, "", writeTimeout, false);
+    DataTransferEncryptorMessageProto msg;
+    readSaslMessage(sock, writeTimeout*10, msg, datanode);
+    if (saslClient)
+        delete saslClient;
+
+    RpcSaslProto_SaslAuth auth;
+    auth.set_method("TOKEN");
+    auth.set_mechanism("DIGEST-MD5");
+    std::string temp;
+    Token ourToken;
+    ourToken.setIdentifier(blockToken.getIdentifier());
+    ourToken.setKind(blockToken.getKind());
+    ourToken.setPassword(blockToken.getPassword());
+    ourToken.setService(blockToken.getService());
+
+    if (isSecure && theKey.getNonce().length() == 0)
+        isSecure = false;
+
+    if (isSecure) {
+        char temp[100];
+        std::string nonce = theKey.getNonce();
+        std::string user;
+        sprintf(temp, "%d", theKey.getKeyId());
+        user = temp;
+        user += " ";
+        user += theKey.getBlockPoolId();
+        user += " ";
+        user += Base64Encode(nonce);
+        ourToken.setIdentifier(user);
+        ourToken.setPassword(theKey.getEncryptionKey());
+    }
+
+    temp = "0";
+    auth.set_serverid(temp);
+    temp = "hdfs";
+    auth.set_protocol(temp);
+    saslClient = new SaslClient(auth, ourToken, "", isSecure, protection);
+    std::string token = saslClient->evaluateChallenge(msg.payload());
+    sendSaslMessage(sock, DataTransferEncryptorMessageProto_DataTransferEncryptorStatus_SUCCESS,
+        token, "", writeTimeout, isSecure);
+    readSaslMessage(sock, writeTimeout*10, msg, datanode);
+
+
+
+    token = saslClient->evaluateChallenge(msg.payload());
+    if (token.length() != 0) {
+        THROW(HdfsRpcException,
+              "DataNode to \"%s\" got protocol mismatch: got error evaluating challenge.",
+              datanode.c_str())
+    }
+
+    if (msg.cipheroption().size()) {
+        CipherOptionProto cipher = msg.cipheroption().Get(0);
+        std::string inKey = cipher.inkey();
+        std::string inIv = cipher.iniv();
+        std::string outKey = cipher.outkey();
+        std::string outIv = cipher.outiv();
+
+        inKey = saslClient->decode(inKey.c_str(), inKey.length());
+        outKey = saslClient->decode(outKey.c_str(), outKey.length());
+
+        AESClient *aes = new AESClient(inKey, inIv, outKey, outIv, cryptoBufferSize);
+        saslClient->setAes(aes);
+    }
+    saslComplete = true;
+
 }
 }
 }

--- a/src/client/DataTransferProtocolSender.h
+++ b/src/client/DataTransferProtocolSender.h
@@ -30,6 +30,8 @@
 
 #include "DataTransferProtocol.h"
 #include "network/Socket.h"
+#include "rpc/SaslClient.h"
+#include "server/EncryptionKey.h"
 
 /**
  * Version 28:
@@ -58,7 +60,9 @@ enum DataTransferOp {
 class DataTransferProtocolSender: public DataTransferProtocol {
 public:
     DataTransferProtocolSender(Socket & sock, int writeTimeout,
-                               const std::string & datanodeAddr);
+                               const std::string & datanodeAddr,
+                               bool secure, bool token, EncryptionKey& key,
+                               int32_t cryptoBufferSize, int32_t protection);
 
     virtual ~DataTransferProtocolSender();
 
@@ -131,10 +135,27 @@ public:
                                         const Token& blockToken,
                                         uint32_t maxVersion);
 
+    virtual bool needsLength();
+    virtual bool isWrapped();
+
+    virtual std::string unwrap(std::string &data);
+    virtual std::string wrap(std::string &data);
+    virtual std::string unwrap(const char *input, size_t input_len);
+    virtual std::string wrap(const char *input, size_t input_len);
+private:
+    void setupSasl(const ExtendedBlock blk, const Token& blockToken);
+
 private:
     Socket & sock;
     int writeTimeout;
     std::string datanode;
+    bool isSecure;
+    bool isToken;
+    bool saslComplete;
+    SaslClient *saslClient;
+    EncryptionKey theKey;
+    int32_t cryptoBufferSize;
+    int32_t protection;
 };
 
 }

--- a/src/client/FileSystem.cpp
+++ b/src/client/FileSystem.cpp
@@ -196,6 +196,12 @@ FileSystem::~FileSystem() {
     }
 }
 
+EncryptionKey FileSystem::getEncryptionKeys() {
+    if (impl)
+        return impl->filesystem->getEncryptionKeys();
+    return EncryptionKey();
+}
+
 void FileSystem::connect() {
     Internal::SessionConfig sconf(conf);
     connect(sconf.getDefaultUri().c_str(), NULL, NULL);

--- a/src/client/FileSystem.h
+++ b/src/client/FileSystem.h
@@ -34,6 +34,7 @@
 #include "FileSystemStats.h"
 #include "Permission.h"
 #include "XmlConfig.h"
+#include "server/EncryptionKey.h"
 
 #include <vector>
 
@@ -90,6 +91,8 @@ public:
      * disconnect from hdfs
      */
     void disconnect();
+
+    Internal::EncryptionKey getEncryptionKeys();
 
     /**
      * To get default number of replication.

--- a/src/client/FileSystemImpl.cpp
+++ b/src/client/FileSystemImpl.cpp
@@ -191,6 +191,14 @@ void FileSystemImpl::connect() {
      * To test if the connection is ok
      */
     getFsStats();
+    if (sconf.getEncryptedDatanode())
+        nn->getEncryptionKeys();
+}
+
+EncryptionKey FileSystemImpl::getEncryptionKeys() {
+    if (sconf.getEncryptedDatanode())
+        return nn->getEncryptionKeys();
+    return EncryptionKey();
 }
 
 /**

--- a/src/client/FileSystemImpl.h
+++ b/src/client/FileSystemImpl.h
@@ -80,6 +80,8 @@ public:
      */
     const char * getClientName();
 
+    EncryptionKey getEncryptionKeys();
+
     /**
      * Connect to hdfs
      */
@@ -443,7 +445,7 @@ public:
      * Get the configuration used in filesystem.
      * @return return the configuration instance.
      */
-    const SessionConfig & getConf() const {
+    SessionConfig & getConf()  {
         return sconf;
     }
 

--- a/src/client/FileSystemInter.h
+++ b/src/client/FileSystemInter.h
@@ -43,6 +43,8 @@
 #include "Unordered.h"
 #include "UserInfo.h"
 #include "XmlConfig.h"
+#include "server/EncryptionKey.h"
+
 
 namespace Hdfs {
 
@@ -93,6 +95,8 @@ public:
      * disconnect from hdfs
      */
     virtual void disconnect() = 0;
+
+    virtual EncryptionKey getEncryptionKeys() = 0;
 
     /**
      * To get default number of replication.
@@ -454,7 +458,7 @@ public:
      * Get the configuration used in filesystem.
      * @return return the configuration instance.
      */
-    virtual const SessionConfig & getConf() const = 0;
+    virtual SessionConfig & getConf() = 0;
 
     /**
      * Get the user used in filesystem.

--- a/src/client/InputStreamImpl.cpp
+++ b/src/client/InputStreamImpl.cpp
@@ -355,9 +355,10 @@ void InputStreamImpl::setupBlockReader(bool temporaryDisableLocalRead) {
 
                 shared_ptr<ReadShortCircuitInfo> info;
                 ReadShortCircuitInfoBuilder builder(curNode, auth, *conf);
+                EncryptionKey ekey = filesystem->getEncryptionKeys();
 
                 try {
-                    info = builder.fetchOrCreate(*curBlock, curBlock->getToken());
+                    info = builder.fetchOrCreate(*curBlock, curBlock->getToken(), ekey);
 
                     if (!info) {
                         continue;
@@ -378,6 +379,7 @@ void InputStreamImpl::setupBlockReader(bool temporaryDisableLocalRead) {
                 const char * clientName = filesystem->getClientName();
                 lastReadFromLocal = false;
                 blockReader = shared_ptr<BlockReader>(new RemoteBlockReader(
+                    filesystem,
                     *curBlock, curNode, *peerCache, offset, len,
                     curBlock->getToken(), clientName, verify, *conf));
             }
@@ -398,10 +400,16 @@ void InputStreamImpl::setupBlockReader(bool temporaryDisableLocalRead) {
                  * disable local block reading
                  */
             } else {
-                LOG(LOG_ERROR,
-                    "cannot setup block reader for Block: %s file %s on Datanode: %s.\n%s\nretry another node",
-                    curBlock->toString().c_str(), path.c_str(),
-                    curNode.formatAddress().c_str(), GetExceptionDetail(e, buffer));
+                if (conf->getEncryptedDatanode() || conf->getSecureDatanode())
+                    LOG(WARNING,
+                        "cannot setup block reader for Block: %s file %s on Datanode: %s retry another node",
+                        curBlock->toString().c_str(), path.c_str(),
+                        curNode.formatAddress().c_str());
+                else
+                    LOG(LOG_ERROR,
+                        "cannot setup block reader for Block: %s file %s on Datanode: %s.\n%s\nretry another node",
+                        curBlock->toString().c_str(), path.c_str(),
+                        curNode.formatAddress().c_str(), GetExceptionDetail(e, buffer));
                 failedNodes.push_back(curNode);
                 std::sort(failedNodes.begin(), failedNodes.end());
             }
@@ -481,7 +489,7 @@ int32_t InputStreamImpl::readOneBlock(char * buf, int32_t size, bool shouldUpdat
         } catch (const HdfsInvalidBlockToken & e) {
             std::string buffer;
             LOG(LOG_ERROR,
-                "InputStreamImpl: failed to read Block: %s file %s, \n%s, retry after updating block informations.",
+                "InputStreamImpl: failed to read Block (stale token): %s file %s, \n%s, retry after updating block informations.",
                 curBlock->toString().c_str(), path.c_str(), GetExceptionDetail(e, buffer));
             return -1;
         } catch (const HdfsIOException & e) {
@@ -490,10 +498,15 @@ int32_t InputStreamImpl::readOneBlock(char * buf, int32_t size, bool shouldUpdat
              * We now update block informations once, and try again.
              */
             if (shouldUpdateMetadataOnFailure) {
-                LOG(LOG_ERROR,
-                    "InputStreamImpl: failed to read Block: %s file %s, \n%s, retry after updating block informations.",
-                    curBlock->toString().c_str(), path.c_str(),
-                    GetExceptionDetail(e, buffer));
+                if (conf->getEncryptedDatanode() || conf->getSecureDatanode())
+                    LOG(WARNING,
+                        "InputStreamImpl: failed to read Block: %s file %s, retry after updating block informations.",
+                        curBlock->toString().c_str(), path.c_str());
+                else
+                    LOG(LOG_ERROR,
+                        "InputStreamImpl: failed to read Block: %s file %s, \n%s, retry after updating block informations.",
+                        curBlock->toString().c_str(), path.c_str(),
+                        GetExceptionDetail(e, buffer));
                 return -1;
             } else {
                 /*

--- a/src/client/Pipeline.cpp
+++ b/src/client/Pipeline.cpp
@@ -32,21 +32,30 @@
 #include "ExceptionInternal.h"
 #include "OutputStreamInter.h"
 #include "FileSystemInter.h"
-#include "DataTransferProtocolSender.h"
 #include "datatransfer.pb.h"
+#include "server/Datanode.h"
+#include "DataReader.h"
+
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+
+using namespace ::google::protobuf;
+using namespace google::protobuf::io;
 
 #include <inttypes.h>
 
 namespace Hdfs {
 namespace Internal {
 
-PipelineImpl::PipelineImpl(bool append, const char * path, const SessionConfig & conf,
+PipelineImpl::PipelineImpl(bool append, const char * path, SessionConfig & conf,
                            shared_ptr<FileSystemInter> filesystem, int checksumType, int chunkSize,
                            int replication, int64_t bytesSent, PacketPool & packetPool, shared_ptr<LocatedBlock> lastBlock) :
-    checksumType(checksumType), chunkSize(chunkSize), errorIndex(-1), replication(replication), bytesAcked(
+    config(conf), checksumType(checksumType), chunkSize(chunkSize), errorIndex(-1), replication(replication), bytesAcked(
         bytesSent), bytesSent(bytesSent), packetPool(packetPool), filesystem(filesystem), lastBlock(lastBlock), path(
             path) {
     canAddDatanode = conf.canAddDatanode();
+    canAddDatanodeBest = conf.canAddDatanodeBest();
     blockWriteRetry = conf.getBlockWriteRetry();
     connectTimeout = conf.getOutputConnTimeout();
     readTimeout = conf.getOutputReadTimeout();
@@ -95,16 +104,26 @@ void PipelineImpl::transfer(const ExtendedBlock & blk, const DatanodeInfo & src,
     shared_ptr<Socket> so(new TcpSocketImpl);
     shared_ptr<BufferedSocketReader> in(new BufferedSocketReaderImpl(*so));
     so->connect(src.getIpAddr().c_str(), src.getXferPort(), connectTimeout);
-    DataTransferProtocolSender sender(*so, writeTimeout, src.formatAddress());
+    EncryptionKey key = filesystem->getEncryptionKeys();
+    DataTransferProtocolSender sender(*so, writeTimeout, src.formatAddress(), config.getEncryptedDatanode(),
+        config.getSecureDatanode(), key, config.getCryptoBufferSize(), config.getDataProtection());
     sender.transferBlock(blk, token, clientName.c_str(), targets);
+    char error_text[2048];
+    sprintf(error_text, "from %s for block %s.", nodes[0].formatAddress().c_str(), lastBlock->toString().c_str());
+    DataReader datareader(&sender, in, readTimeout);
     int size;
-    size = in->readVarint32(readTimeout);
-    std::vector<char> buf(size);
-    in->readFully(buf.data(), size, readTimeout);
+    std::vector<char> &buf = datareader.readResponse(error_text, size);
     BlockOpResponseProto resp;
-
     if (!resp.ParseFromArray(buf.data(), size)) {
-        THROW(HdfsIOException, "cannot parse datanode response from %s fro block %s.",
+        DataTransferEncryptorMessageProto resp2;
+        if (resp2.ParseFromArray(buf.data(), size))
+        {
+            if (resp2.status() != DataTransferEncryptorMessageProto_DataTransferEncryptorStatus_SUCCESS) {
+                THROW(HdfsIOException, "Error doing transfer from %s for block %s.: %s",
+              nodes[0].formatAddress().c_str(), lastBlock->toString().c_str(), resp2.message().c_str());
+            }
+        }
+        THROW(HdfsIOException, "cannot parse datanode response from %s for block %s.",
               src.formatAddress().c_str(), lastBlock->toString().c_str());
     }
 
@@ -151,9 +170,22 @@ bool PipelineImpl::addDatanodeToPipeline(const std::vector<DatanodeInfo> & exclu
             targets.push_back(nodes[d]);
             LOG(INFO, "Replicate block %s from %s to %s for file %s.", lastBlock->toString().c_str(),
                 src.formatAddress().c_str(), targets[0].formatAddress().c_str(), path.c_str());
-            transfer(*lastBlock, src, targets, lb->getToken());
-            errorIndex = -1;
-            return true;
+            try {
+                transfer(*lastBlock, src, targets, lb->getToken());
+                errorIndex = -1;
+                return true;
+            } catch (HdfsIOException &ex) {
+                if (!config.getEncryptedDatanode() && config.getSecureDatanode()) {
+                    config.setSecureDatanode(false);
+                    filesystem->getConf().setSecureDatanode(false);
+                    LOG(INFO, "Tried to use SASL connection but failed, falling back to non SASL");
+                    transfer(*lastBlock, src, targets, lb->getToken());
+                    errorIndex = -1;
+                    return true;
+                } else {
+                    throw;
+                }
+            }
         }
     } catch (const HdfsCanceled & e) {
         throw;
@@ -199,8 +231,12 @@ void PipelineImpl::buildForAppendOrRecovery(bool recovery) {
     int retry = blockWriteRetry;
     exception_ptr lastException;
     std::vector<DatanodeInfo> excludedNodes;
+    std::vector<DatanodeInfo> empty;
     shared_ptr<LocatedBlock> lb;
     std::string buffer;
+    DatanodeInfo removed;
+    std::string storageID;
+    bool useRemoved = false;
 
     do {
         /*
@@ -208,20 +244,46 @@ void PipelineImpl::buildForAppendOrRecovery(bool recovery) {
          * If errorIndex was not set (i.e. appends), then do not remove
          * any datanodes
          */
+        useRemoved = false;
+        storageID = "";
         if (errorIndex >= 0) {
             assert(lastBlock);
-            LOG(LOG_ERROR, "Pipeline: node %s is invalid and removed from pipeline when %s block %s for file %s, stage = %s.",
-                nodes[errorIndex].formatAddress().c_str(),
-                (recovery ? "recovery" : "append to"), lastBlock->toString().c_str(),
-                path.c_str(), StageToString(stage));
-            excludedNodes.push_back(nodes[errorIndex]);
+            bool invalid = true;
+            LOG(LOG_ERROR, "Pipeline: node %s had error. Trying to ping to test if valid.",
+                nodes[errorIndex].formatAddress().c_str());
+            try {
+                RpcAuth a = RpcAuth(filesystem->getUserInfo(), RpcAuth::ParseMethod(config.getRpcAuthMethod()));
+                shared_ptr<Datanode> dn = shared_ptr < Datanode > (new DatanodeImpl(nodes[errorIndex].getIpAddr().c_str(),
+                                              nodes[errorIndex].getIpcPort(), config, a));
+                dn->sendPing();
+                invalid = false;
+                LOG(INFO, "Pipeline: node %s was able to ping. Will continue to use.",
+                    nodes[errorIndex].formatAddress().c_str());
+                removed = nodes[errorIndex];
+                if (errorIndex < (int)storageIDs.size())
+                    storageID = storageIDs[errorIndex];
+                useRemoved = true;
+            }
+            catch (...) {
+            }
+            if (invalid) {
+                /*
+                 * If node was pingable, don't exclude it, but do remove it for now. We will then
+                 * be able to add it back later.
+                */
+                LOG(LOG_ERROR, "Pipeline: node %s is invalid and removed from pipeline when %s block %s for file %s, stage = %s.",
+                    nodes[errorIndex].formatAddress().c_str(),
+                    (recovery ? "recovery" : "append to"), lastBlock->toString().c_str(),
+                    path.c_str(), StageToString(stage));
+                excludedNodes.push_back(nodes[errorIndex]);
+            }
             nodes.erase(nodes.begin() + errorIndex);
 
             if (!storageIDs.empty()) {
                 storageIDs.erase(storageIDs.begin() + errorIndex);
             }
 
-            if (nodes.empty()) {
+            if (nodes.empty() && invalid) {
                 THROW(HdfsIOException,
                       "Build pipeline to %s block %s failed: all datanodes are bad.",
                       (recovery ? "recovery" : "append to"), lastBlock->toString().c_str());
@@ -239,12 +301,40 @@ void PipelineImpl::buildForAppendOrRecovery(bool recovery) {
              */
             if (stage != PIPELINE_SETUP_CREATE && stage != PIPELINE_CLOSE
                     && static_cast<int>(nodes.size()) < replication && canAddDatanode) {
-                if (!addDatanodeToPipeline(excludedNodes)) {
-                    THROW(HdfsIOException,
-                          "Failed to add new datanode into pipeline for block: %s file %s, "
-                          "set \"output.replace-datanode-on-failure\" to \"false\" to disable this feature.",
-                          lastBlock->toString().c_str(), path.c_str());
+                // Single data node case
+                bool added = false;
+                if (nodes.empty() && useRemoved) {
+                    if (storageID.length()) {
+                        LOG(INFO, "Pipeline: Adding back only datanode %s", removed.formatAddress().c_str());
+                        nodes.push_back(removed);
+                        lb = filesystem->updateBlockForPipeline(*lastBlock);
+                        storageIDs.push_back(storageID);
+                        lb->setPoolId(lastBlock->getPoolId());
+                        lb->setBlockId(lastBlock->getBlockId());
+                        lb->setLocations(nodes);
+                        lb->setStorageIDs(storageIDs);
+                        lb->setNumBytes(lastBlock->getNumBytes());
+                        lb->setOffset(lastBlock->getOffset());
+                        filesystem->updatePipeline(*lastBlock, *lb, nodes, storageIDs);
+                        added = true;
+                    }
                 }
+                if (!added && !addDatanodeToPipeline(excludedNodes)) {
+
+                    // We may have remove nodes due to timeout, try again, but allow for
+                    // excluded ones to be added back
+                    if (!addDatanodeToPipeline(empty) && !canAddDatanodeBest) {
+                        THROW(HdfsIOException,
+                              "Failed to add new datanode into pipeline for block: %s file %s, "
+                              "set \"output.replace-datanode-on-failure\" to \"false\" to disable this feature.",
+                              lastBlock->toString().c_str(), path.c_str());
+                    }
+                }
+            }
+            if (nodes.empty()) {
+                THROW(HdfsIOException,
+                      "Build pipeline to %s block failed: all datanodes are bad.",
+                      (recovery ? "recovery" : "append to"));
             }
 
             if (errorIndex >= 0) {
@@ -524,19 +614,31 @@ void PipelineImpl::createBlockOutputStream(const Token & token, int64_t gs, bool
         for (size_t i = 1; i < nodes.size(); ++i) {
             targets.push_back(nodes[i]);
         }
-
-        DataTransferProtocolSender sender(*sock, writeTimeout,
-                                          nodes[0].formatAddress());
-        sender.writeBlock(*lastBlock, token, clientName.c_str(), targets,
+        EncryptionKey key = filesystem->getEncryptionKeys();
+        sender = shared_ptr<DataTransferProtocolSender>(new DataTransferProtocolSender(*sock, writeTimeout,
+                                          nodes[0].formatAddress(),
+                                          config.getEncryptedDatanode(),
+                                          config.getSecureDatanode(),
+                                          key, config.getCryptoBufferSize(),
+                                          config.getDataProtection()));
+        sender->writeBlock(*lastBlock, token, clientName.c_str(), targets,
                           (recovery ? (stage | 0x1) : stage), nodes.size(),
                           lastBlock->getNumBytes(), bytesSent, gs, checksumType, chunkSize);
+        char error_text[2048];
+        sprintf(error_text, "from %s for block %s.", nodes[0].formatAddress().c_str(), lastBlock->toString().c_str());
+        DataReader datareader(sender.get(), reader, readTimeout);
         int size;
-        size = reader->readVarint32(readTimeout);
-        std::vector<char> buf(size);
-        reader->readFully(buf.data(), size, readTimeout);
+        std::vector<char> &buf = datareader.readResponse(error_text, size);
         BlockOpResponseProto resp;
-
         if (!resp.ParseFromArray(buf.data(), size)) {
+            DataTransferEncryptorMessageProto resp2;
+            if (resp2.ParseFromArray(buf.data(), size))
+            {
+                if (resp2.status() != DataTransferEncryptorMessageProto_DataTransferEncryptorStatus_SUCCESS) {
+                    THROW(HdfsIOException, "Error creating output stream from %s for block %s.: %s",
+                  nodes[0].formatAddress().c_str(), lastBlock->toString().c_str(), resp2.message().c_str());
+                }
+            }
             THROW(HdfsIOException, "cannot parse datanode response from %s for block %s.",
                   nodes[0].formatAddress().c_str(), lastBlock->toString().c_str());
         }
@@ -558,6 +660,17 @@ void PipelineImpl::createBlockOutputStream(const Token & token, int64_t gs, bool
         }
 
         return;
+    } catch (HdfsIOException &ex) {
+        if (!config.getEncryptedDatanode() && config.getSecureDatanode()) {
+            config.setSecureDatanode(false);
+            filesystem->getConf().setSecureDatanode(false);
+            LOG(INFO, "Tried to use SASL connection but failed, falling back to non SASL");
+            createBlockOutputStream(token, gs, recovery);
+            return;
+        } else {
+            errorIndex = 0;
+            lastError = current_exception();
+        }
     } catch (...) {
         errorIndex = 0;
         lastError = current_exception();
@@ -595,7 +708,24 @@ void PipelineImpl::resend() {
 
     for (size_t i = 0; i < packets.size(); ++i) {
         ConstPacketBuffer b = packets[i]->getBuffer();
-        sock->writeFully(b.getBuffer(), b.getSize(), writeTimeout);
+        if (sender && sender->isWrapped()) {
+            std::string indata;
+            int size = b.getSize();
+            indata.resize(size);
+            memcpy(indata.data(), b.getBuffer(), size);
+            std::string data = sender->wrap(indata);
+            WriteBuffer buffer;
+            if (sender->needsLength())
+                buffer.writeBigEndian(static_cast<int32_t>(data.length()));
+            char * b = buffer.alloc(data.length());
+            memcpy(b, data.c_str(), data.length());
+            sock->writeFully(buffer.getBuffer(0), buffer.getDataSize(0),
+                         writeTimeout);
+        }
+        else {
+            sock->writeFully(b.getBuffer(), b.getSize(),
+                             writeTimeout);
+        }
         int64_t tmp = packets[i]->getLastByteOffsetBlock();
         bytesSent = bytesSent > tmp ? bytesSent : tmp;
     }
@@ -623,8 +753,24 @@ void PipelineImpl::send(shared_ptr<Packet> packet) {
                 resend();
             } else {
                 assert(sock);
-                sock->writeFully(buffer.getBuffer(), buffer.getSize(),
+                if (sender && sender->isWrapped()) {
+                    std::string indata;
+                    int size = buffer.getSize();
+                    indata.resize(size);
+                    memcpy(indata.data(), buffer.getBuffer(), size);
+                    std::string data = sender->wrap(indata);
+                    WriteBuffer buffer2;
+                    if (sender->needsLength())
+                        buffer2.writeBigEndian(static_cast<int32_t>(data.length()));
+                    char * b = buffer2.alloc(data.length());
+                    memcpy(b, data.c_str(), data.length());
+                    sock->writeFully(buffer2.getBuffer(0), buffer2.getDataSize(0),
                                  writeTimeout);
+                }
+                else {
+                    sock->writeFully(buffer.getBuffer(), buffer.getSize(),
+                                     writeTimeout);
+                }
                 int64_t tmp = packet->getLastByteOffsetBlock();
                 bytesSent = bytesSent > tmp ? bytesSent : tmp;
             }
@@ -696,20 +842,24 @@ void PipelineImpl::processAck(PipelineAck & ack) {
 
 void PipelineImpl::processResponse() {
     PipelineAck ack;
-    std::vector<char> buf;
-    int size = reader->readVarint32(readTimeout);
-    ack.reset();
-    buf.resize(size);
-    reader->readFully(buf.data(), size, readTimeout);
-    ack.readFrom(buf.data(), size);
+    int size = 0;
+    char error_text[2048];
+    sprintf(error_text, "for block %s.", lastBlock->toString().c_str());
+    DataReader datareader(sender.get(), reader, readTimeout);
 
-    if (ack.isInvalid()) {
-        THROW(HdfsIOException,
-              "processAllAcks: get an invalid DataStreamer packet ack for block %s",
-              lastBlock->toString().c_str());
-    }
+    do {
+        std::vector<char> &buf = datareader.readResponse(error_text, size);
+        ack.reset();
+        ack.readFrom(buf.data(), size);
 
-    processAck(ack);
+        if (ack.isInvalid()) {
+            THROW(HdfsIOException,
+                  "processAllAcks: get an invalid DataStreamer packet ack for block %s",
+                  lastBlock->toString().c_str());
+        }
+
+        processAck(ack);
+    } while (datareader.getRest().size() > 0);
 }
 
 void PipelineImpl::checkResponse(bool wait) {

--- a/src/client/Pipeline.h
+++ b/src/client/Pipeline.h
@@ -40,6 +40,7 @@
 #include "server/Namenode.h"
 #include "SessionConfig.h"
 #include "Thread.h"
+#include "DataTransferProtocolSender.h"
 
 #include <vector>
 #include <deque>
@@ -130,7 +131,7 @@ public:
     /**
      * construct and setup the pipeline for append.
      */
-    PipelineImpl(bool append, const char * path, const SessionConfig & conf,
+    PipelineImpl(bool append, const char * path, SessionConfig & conf,
                  shared_ptr<FileSystemInter> filesystem, int checksumType, int chunkSize,
                  int replication, int64_t bytesSent, PacketPool & packetPool,
                  shared_ptr<LocatedBlock> lastBlock);
@@ -172,8 +173,10 @@ private:
     static void checkBadLinkFormat(const std::string & node);
 
 private:
+    SessionConfig & config;
     BlockConstructionStage stage;
     bool canAddDatanode;
+    bool canAddDatanodeBest;
     int blockWriteRetry;
     int checksumType;
     int chunkSize;
@@ -186,6 +189,7 @@ private:
     int64_t bytesSent; //the size of bytes has sent.
     PacketPool & packetPool;
     shared_ptr<BufferedSocketReader> reader;
+    shared_ptr<DataTransferProtocolSender> sender;
     shared_ptr<FileSystemInter> filesystem;
     shared_ptr<LocatedBlock> lastBlock;
     shared_ptr<Socket> sock;

--- a/src/client/ReadShortCircuitInfo.cpp
+++ b/src/client/ReadShortCircuitInfo.cpp
@@ -72,7 +72,7 @@ ReadShortCircuitInfoBuilder::ReadShortCircuitInfoBuilder(
     : dnInfo(dnInfo), auth(auth), conf(conf) {}
 
 shared_ptr<ReadShortCircuitInfo> ReadShortCircuitInfoBuilder::fetchOrCreate(
-    const ExtendedBlock& block, const Token token) {
+    const ExtendedBlock& block, const Token token, EncryptionKey& ekey) {
   shared_ptr<ReadShortCircuitInfo> retval;
   ReadShortCircuitInfoKey key(dnInfo.getXferPort(), block.getBlockId(),
                               block.getPoolId());
@@ -116,7 +116,7 @@ shared_ptr<ReadShortCircuitInfo> ReadShortCircuitInfoBuilder::fetchOrCreate(
     }
 
     // create a new one
-    retval = createReadShortCircuitInfo(key, block, token);
+    retval = createReadShortCircuitInfo(key, block, token, ekey);
     ReadShortCircuitFDCache.setMaxSize(conf.getMaxFileDescriptorCacheSize());
   }
 
@@ -239,11 +239,12 @@ std::string ReadShortCircuitInfoBuilder::buildDomainSocketAddress(
 shared_ptr<ReadShortCircuitInfo>
 ReadShortCircuitInfoBuilder::createReadShortCircuitInfo(
     const ReadShortCircuitInfoKey& key, const ExtendedBlock& block,
-    const Token& token) {
+    const Token& token, EncryptionKey& ekey) {
   std::string addr = buildDomainSocketAddress(key.dnPort);
   DomainSocketImpl sock;
   sock.connect(addr.c_str(), 0, conf.getInputConnTimeout());
-  DataTransferProtocolSender sender(sock, conf.getInputWriteTimeout(), addr);
+  DataTransferProtocolSender sender(sock, conf.getInputWriteTimeout(), addr, conf.getEncryptedDatanode(),
+    conf.getSecureDatanode(), ekey, conf.getCryptoBufferSize(), conf.getDataProtection());
   sender.requestShortCircuitFds(block, token, MaxReadShortCircuitVersion);
   shared_ptr<ReadShortCircuitFDHolder> fds =
       receiveReadShortCircuitFDs(sock, block);

--- a/src/client/ReadShortCircuitInfo.h
+++ b/src/client/ReadShortCircuitInfo.h
@@ -37,6 +37,7 @@
 #include "server/BlockLocalPathInfo.h"
 #include "server/DatanodeInfo.h"
 #include "server/ExtendedBlock.h"
+#include "server/EncryptionKey.h"
 #include "SessionConfig.h"
 #include "Thread.h"
 #include "Token.h"
@@ -157,7 +158,8 @@ class ReadShortCircuitInfoBuilder {
   ReadShortCircuitInfoBuilder(const DatanodeInfo& dnInfo, const RpcAuth& auth,
                               const SessionConfig& conf);
   shared_ptr<ReadShortCircuitInfo> fetchOrCreate(const ExtendedBlock& block,
-                                                 const Token token);
+                                                 const Token token,
+                                                 EncryptionKey& ekey);
   static void release(const ReadShortCircuitInfo& info);
 
  private:
@@ -168,7 +170,7 @@ class ReadShortCircuitInfoBuilder {
       const ReadShortCircuitInfoKey& key, const BlockLocalPathInfo& info);
   shared_ptr<ReadShortCircuitInfo> createReadShortCircuitInfo(
       const ReadShortCircuitInfoKey& key, const ExtendedBlock& block,
-      const Token& token);
+      const Token& token, EncryptionKey& ekey);
   shared_ptr<ReadShortCircuitInfo> createReadShortCircuitInfo(
       const ReadShortCircuitInfoKey& key,
       const shared_ptr<ReadShortCircuitFDHolder>& fds);

--- a/src/client/RemoteBlockReader.cpp
+++ b/src/client/RemoteBlockReader.cpp
@@ -35,6 +35,11 @@
 #include "IntelAsmCrc32c.h"
 #include "WriteBuffer.h"
 
+#include <google/protobuf/io/coded_stream.h>
+
+using namespace ::google::protobuf;
+using namespace google::protobuf::io;
+
 #include <inttypes.h>
 #include <memory>
 #include <vector>
@@ -42,7 +47,8 @@
 namespace Hdfs {
 namespace Internal {
 
-RemoteBlockReader::RemoteBlockReader(const ExtendedBlock& eb,
+RemoteBlockReader::RemoteBlockReader(shared_ptr<FileSystemInter> filesystem,
+                                     const ExtendedBlock& eb,
                                      DatanodeInfo& datanode,
                                      PeerCache& peerCache, int64_t start,
                                      int64_t len, const Token& token,
@@ -59,26 +65,54 @@ RemoteBlockReader::RemoteBlockReader(const ExtendedBlock& eb,
       cursor(start),
       endOffset(len + start),
       lastSeqNo(-1),
-      peerCache(peerCache) {
+      peerCache(peerCache),
+      filesystem(filesystem) {
 
     assert(start >= 0);
     readTimeout = conf.getInputReadTimeout();
     writeTimeout = conf.getInputWriteTimeout();
     connTimeout = conf.getInputConnTimeout();
-    sock = getNextPeer(datanode);
-    in = shared_ptr<BufferedSocketReader>(new BufferedSocketReaderImpl(*sock));
-    sender = shared_ptr<DataTransferProtocol>(new DataTransferProtocolSender(
-        *sock, writeTimeout, datanode.formatAddress()));
-    sender->readBlock(eb, token, clientName, start, len);
+    setupReader(conf);
+    try {
+        sender->readBlock(eb, token, clientName, start, len);
+    } catch (HdfsIOException &ex) {
+        if (!conf.getEncryptedDatanode() && conf.getSecureDatanode()) {
+            conf.setSecureDatanode(false);
+            filesystem->getConf().setSecureDatanode(false);
+            LOG(INFO, "Tried to use SASL connection but failed, falling back to non SASL");
+            cleanupSocket();
+            setupReader(conf);
+            sender->readBlock(eb, token, clientName, start, len);
+        } else {
+            throw;
+        }
+    }
     checkResponse();
 }
 
-RemoteBlockReader::~RemoteBlockReader() {
-    if (sentStatus) {
+void RemoteBlockReader::setupReader(SessionConfig& conf)
+{
+    sock = getNextPeer(datanode);
+    EncryptionKey key = filesystem->getEncryptionKeys();
+    in = shared_ptr<BufferedSocketReader>(new BufferedSocketReaderImpl(*sock));
+    sender = shared_ptr<DataTransferProtocol>(new DataTransferProtocolSender(
+        *sock, writeTimeout, datanode.formatAddress(), conf.getEncryptedDatanode(),
+        conf.getSecureDatanode(), key, conf.getCryptoBufferSize(), conf.getDataProtection()));
+    reader = shared_ptr<DataReader>(new DataReader(sender.get(), in, readTimeout));
+}
+
+void RemoteBlockReader::cleanupSocket() {
+    bool reuse = sentStatus && sender == NULL;
+    if (reuse) {
         peerCache.addConnection(sock, datanode);
     } else {
         sock->close();
     }
+
+}
+
+RemoteBlockReader::~RemoteBlockReader() {
+    cleanupSocket();
 }
 
 shared_ptr<Socket> RemoteBlockReader::getNextPeer(const DatanodeInfo& dn) {
@@ -102,19 +136,23 @@ shared_ptr<Socket> RemoteBlockReader::getNextPeer(const DatanodeInfo& dn) {
 }
 
 void RemoteBlockReader::checkResponse() {
-    std::vector<char> respBuffer;
-    int32_t respSize = in->readVarint32(readTimeout);
+    int32_t respSize = 0;
+    char error_text[2048];
+    sprintf(error_text, "Block: %s, from Datanode: %s.", binfo.toString().c_str(), datanode.formatAddress().c_str());
+    std::vector<char> &respBuffer = reader->readResponse(error_text, respSize);
 
-    if (respSize <= 0 || respSize > 10 * 1024 * 1024) {
-        THROW(HdfsIOException, "RemoteBlockReader get a invalid response size: %d, Block: %s, from Datanode: %s",
-              respSize, binfo.toString().c_str(), datanode.formatAddress().c_str());
-    }
-
-    respBuffer.resize(respSize);
-    in->readFully(respBuffer.data(), respSize, readTimeout);
     BlockOpResponseProto resp;
 
     if (!resp.ParseFromArray(respBuffer.data(), respBuffer.size())) {
+        DataTransferEncryptorMessageProto resp2;
+        if (resp2.ParseFromArray(respBuffer.data(), respBuffer.size()))
+        {
+            if (resp2.status() != DataTransferEncryptorMessageProto_DataTransferEncryptorStatus_SUCCESS) {
+                THROW(HdfsIOException, "Error checking response for block: %s, from Datanode: %s: %s",
+              binfo.toString().c_str(), datanode.formatAddress().c_str(), resp2.message().c_str());
+            }
+        }
+
         THROW(HdfsIOException, "RemoteBlockReader cannot parse BlockOpResponseProto from Datanode response, "
               "Block: %s, from Datanode: %s", binfo.toString().c_str(), datanode.formatAddress().c_str());
     }
@@ -197,8 +235,52 @@ shared_ptr<PacketHeader> RemoteBlockReader::readPacketHeader() {
             THROW(HdfsIOException, "RemoteBlockReader: read over block end from Datanode: %s, Block: %s.",
                   datanode.formatAddress().c_str(), binfo.toString().c_str());
         }
+        if (sender->isWrapped()) {
+            std::string data;
 
-        in->readFully(buf.data(), packetHeaderLen, readTimeout);
+            if (sender->needsLength()) {
+
+                std::string rest = reader->getRest();
+                if (rest.size()) {
+                    data = rest;
+                    reader->reduceRest(packetHeaderLen);
+                }
+                else {
+                    int respSize = in->readBigEndianInt32(readTimeout);
+                    std::vector<char> respBuffer;
+                    if (respSize <= 0 || respSize > 10 * 1024 * 1024) {
+                        THROW(HdfsIOException, "RemoteBlockReader get a invalid packer header size: %d, Block: %s, from Datanode: %s",
+                              respSize, binfo.toString().c_str(), datanode.formatAddress().c_str());
+                    }
+
+                    respBuffer.resize(respSize);
+                    in->readFully(respBuffer.data(), respSize, readTimeout);
+                    data = sender->unwrap(&respBuffer[0], respSize);
+                    if (packetHeaderLen > (int)data.length()) {
+                        THROW(HdfsIOException, "RemoteBlockReader get a invalid packer header size: %d, Block: %s, from Datanode: %s",
+                              (int)data.length(), binfo.toString().c_str(), datanode.formatAddress().c_str());
+                    }
+                    reader->setRest(data.c_str()+packetHeaderLen, data.size()-packetHeaderLen);
+                }
+            } else {
+                int32_t respSize = 0;
+                char error_text[2048];
+                sprintf(error_text, "Block: %s, from Datanode: %s.", binfo.toString().c_str(), datanode.formatAddress().c_str());
+                std::vector<char> &respBuffer = reader->readPacketHeader(error_text, packetHeaderLen, respSize);
+                data = std::string(respBuffer.begin(), respBuffer.end());
+                if (packetHeaderLen > (int)data.length()) {
+                    THROW(HdfsIOException, "RemoteBlockReader get a invalid packer header size: %d, Block: %s, from Datanode: %s",
+                          (int)data.length(), binfo.toString().c_str(), datanode.formatAddress().c_str());
+                }
+            }
+
+
+            buf.resize(data.length());
+            memcpy(buf.data(), data.c_str(), data.length());
+
+        } else {
+            in->readFully(buf.data(), packetHeaderLen, readTimeout);
+        }
         retval = shared_ptr<PacketHeader>(new PacketHeader);
         retval->readFields(buf.data(), packetHeaderLen);
         return retval;
@@ -227,7 +309,17 @@ void RemoteBlockReader::readNextPacket() {
         size = checksumLen + dataSize;
         assert(size == lastHeader->getPacketLen() - static_cast<int>(sizeof(int32_t)));
         buffer.resize(size);
-        in->readFully(buffer.data(), size, readTimeout);
+        if (!sender->isWrapped()) {
+            in->readFully(buffer.data(), size, readTimeout);
+        } else {
+            std::string& rest = reader->getRest();
+            if ((int)rest.size() < size) {
+                reader->getMissing(size);
+                rest = reader->getRest();
+            }
+            memcpy(buffer.data(), &rest[0], size);
+            reader->reduceRest(size);
+        }
         lastSeqNo = lastHeader->getSeqno();
 
         if (lastHeader->getPacketLen() != static_cast<int>(sizeof(int32_t)) + dataSize + checksumLen) {
@@ -284,7 +376,23 @@ void RemoteBlockReader::sendStatus() {
     int size = status.ByteSize();
     buffer.writeVarint32(size);
     status.SerializeToArray(buffer.alloc(size), size);
-    sock->writeFully(buffer.getBuffer(0), buffer.getDataSize(0), writeTimeout);
+    if (sender && sender->isWrapped()) {
+        std::string indata;
+        int size = buffer.getDataSize(0);
+        indata.resize(size);
+        memcpy(indata.data(), buffer.getBuffer(0), size);
+        std::string data = sender->wrap(indata);
+        WriteBuffer buffer2;
+        if (sender->needsLength()) {
+            buffer2.writeBigEndian(static_cast<int32_t>(data.length()));
+        }
+        char * b = buffer2.alloc(data.length());
+        memcpy(b, data.c_str(), data.length());
+        sock->writeFully(buffer2.getBuffer(0), buffer2.getDataSize(0),
+                     writeTimeout);
+    } else {
+        sock->writeFully(buffer.getBuffer(0), buffer.getDataSize(0), writeTimeout);
+    }
     sentStatus = true;
 }
 

--- a/src/client/RemoteBlockReader.h
+++ b/src/client/RemoteBlockReader.h
@@ -38,14 +38,18 @@
 #include "PeerCache.h"
 #include "server/DatanodeInfo.h"
 #include "server/LocatedBlocks.h"
+#include "FileSystemInter.h"
 #include "SessionConfig.h"
+#include "DataReader.h"
+
 
 namespace Hdfs {
 namespace Internal {
 
 class RemoteBlockReader: public BlockReader {
 public:
-    RemoteBlockReader(const ExtendedBlock& eb, DatanodeInfo& datanode,
+    RemoteBlockReader(shared_ptr<FileSystemInter> filesystem,
+                      const ExtendedBlock& eb, DatanodeInfo& datanode,
                       PeerCache& peerCache, int64_t start, int64_t len,
                       const Token& token, const char* clientName, bool verify,
                       SessionConfig& conf);
@@ -82,6 +86,9 @@ private:
     void sendStatus();
     void verifyChecksum(int chunks);
 
+    void setupReader(SessionConfig& conf);
+    void cleanupSocket();
+
 private:
     bool sentStatus;
     bool verify; //verify checksum or not.
@@ -101,9 +108,11 @@ private:
     shared_ptr<BufferedSocketReader> in;
     shared_ptr<Checksum> checksum;
     shared_ptr<DataTransferProtocol> sender;
+    shared_ptr<DataReader> reader;
     shared_ptr<PacketHeader> lastHeader;
     shared_ptr<Socket> sock;
     std::vector<char> buffer;
+    shared_ptr<FileSystemInter> filesystem;
 };
 
 }

--- a/src/common/SessionConfig.cpp
+++ b/src/common/SessionConfig.cpp
@@ -29,7 +29,7 @@
 #include "ExceptionInternal.h"
 #include "Function.h"
 #include "SessionConfig.h"
-
+#include "rpc/RpcAuth.h"
 #include <sstream>
 
 #define ARRAYSIZE(A) (sizeof(A) / sizeof(A[0]))
@@ -55,6 +55,20 @@ static void CheckMultipleOf(const char * key, const T & value, int unit) {
     }
 }
 
+int32_t parseProtection(std::string &str) {
+    if (0 == strcasecmp(str.c_str(), "authentication")) {
+        return Protection::AUTH;
+    } else if (0 == strcasecmp(str.c_str(), "privacy")) {
+        return Protection::CONF;
+    } else if (0 == strcasecmp(str.c_str(), "integrity")) {
+        return Protection::INT;
+    } else {
+        THROW(InvalidParameter, "SessionConfig: Unknown protection mechanism type: %s",
+              str.c_str());
+    }
+
+}
+
 SessionConfig::SessionConfig(const Config & conf) {
     ConfigDefault<bool> boolValues [] = {
         {
@@ -64,11 +78,17 @@ SessionConfig::SessionConfig(const Config & conf) {
         }, {
             &addDatanode, "output.replace-datanode-on-failure", true
         }, {
+            &addDatanodeBest, "output.replace-datanode-on-failure.best-effort", true
+        },{
             &notRetryAnotherNode, "input.notretry-another-node", false
         }, {
-            &useMappedFile, "input.localread.mappedfile", true
+            &useMappedFile, "input.localread.mappedfile", false
         }, {
             &legacyLocalBlockReader, "dfs.client.use.legacy.blockreader.local", false
+        }, {
+            &encryptedDatanode, "dfs.encrypt.data.transfer", false
+        },{
+            &secureDatanode, "dfs.block.access.token.enable", false
         }
     };
     ConfigDefault<int32_t> i32Values[] = {
@@ -132,6 +152,8 @@ SessionConfig::SessionConfig(const Config & conf) {
             &socketCacheExpiry, "dfs.client.socketcache.expiryMsec", 3000, bind(CheckRangeGE<int32_t>, _1, _2, 0)
         }, {
             &socketCacheCapacity, "dfs.client.socketcache.capacity", 16, bind(CheckRangeGE<int32_t>, _1, _2, 0)
+        }, {
+            &cryptoBufferSize, "hadoop.security.crypto.buffer.size", 8192,
         }
     };
     ConfigDefault<int64_t> i64Values [] = {
@@ -144,7 +166,9 @@ SessionConfig::SessionConfig(const Config & conf) {
         {&rpcAuthMethod, "hadoop.security.authentication", "simple" },
         {&kerberosCachePath, "hadoop.security.kerberos.ticket.cache.path", "" },
         {&logSeverity, "dfs.client.log.severity", "INFO" },
-        {&domainSocketPath, "dfs.domain.socket.path", ""}
+        {&domainSocketPath, "dfs.domain.socket.path", ""},
+        {&rpcProtectionStr, "hadoop.rpc.protection", ""},
+        {&dataProtectionStr, "dfs.data.transfer.protection", ""}
     };
 
     for (size_t i = 0; i < ARRAYSIZE(boolValues); ++i) {
@@ -181,6 +205,17 @@ SessionConfig::SessionConfig(const Config & conf) {
         if (strValues[i].check) {
             strValues[i].check(strValues[i].key, *strValues[i].variable);
         }
+    }
+
+    if (rpcProtectionStr.length() > 0) {
+        rpcProtection = parseProtection(rpcProtectionStr);
+    } else {
+        rpcProtection = 0;
+    }
+    if (dataProtectionStr.length() > 0) {
+        dataProtection = parseProtection(dataProtectionStr);
+    } else {
+        dataProtection = 0;
     }
 }
 

--- a/src/common/SessionConfig.h
+++ b/src/common/SessionConfig.h
@@ -104,6 +104,22 @@ public:
         return defaultBlockSize;
     }
 
+    bool getEncryptedDatanode() const {
+        return encryptedDatanode;
+    }
+
+    bool getSecureDatanode() const {
+        return secureDatanode;
+    }
+
+    void setSecureDatanode(bool val) {
+        secureDatanode = val;
+    }
+
+    int32_t getCryptoBufferSize() const {
+        return cryptoBufferSize;
+    }
+
     /*
      * InputStream configure
      */
@@ -174,6 +190,10 @@ public:
 
     bool canAddDatanode() const {
         return addDatanode;
+    }
+
+    bool canAddDatanodeBest() const {
+        return addDatanodeBest;
     }
 
     int32_t getHeartBeatInterval() const {
@@ -307,7 +327,21 @@ public:
       return socketCacheCapacity;
     }
 
+    int32_t getRpcProtection() const {
+        return rpcProtection;
+    }
+
+    int32_t getDataProtection() const {
+        return dataProtection;
+    }
+
 public:
+
+    int32_t rpcProtection;
+    int32_t dataProtection;
+    std::string rpcProtectionStr;
+    std::string dataProtectionStr;
+
     /*
      * rpc configure
      */
@@ -331,6 +365,9 @@ public:
     std::string logSeverity;
     int32_t defaultReplica;
     int64_t defaultBlockSize;
+    bool encryptedDatanode;
+    bool secureDatanode;
+    int32_t cryptoBufferSize;
 
     /*
      * InputStream configure
@@ -356,6 +393,7 @@ public:
      * OutputStream configure
      */
     bool addDatanode;
+    bool addDatanodeBest;
     int32_t chunkSize;
     int32_t packetSize;
     int32_t blockWriteRetry; //retry on block not replicated yet.

--- a/src/proto/datatransfer.proto
+++ b/src/proto/datatransfer.proto
@@ -34,6 +34,19 @@ package Hdfs.Internal;
 import "Security.proto";
 import "hdfs.proto";
 
+enum CipherSuiteProto {
+    UNKNOWN_CIPHER = 1;
+    AES_CTR_NOPADDING = 2;
+}
+
+message CipherOptionProto {
+  required CipherSuiteProto suite = 1;
+  optional bytes inKey = 2;
+  optional bytes inIv = 3;
+  optional bytes outKey = 4;
+  optional bytes outIv = 5;
+}
+
 message DataTransferEncryptorMessageProto {
   enum DataTransferEncryptorStatus {
     SUCCESS = 0;
@@ -43,6 +56,7 @@ message DataTransferEncryptorMessageProto {
   required DataTransferEncryptorStatus status = 1;
   optional bytes payload = 2;
   optional string message = 3;
+  repeated CipherOptionProto cipherOption = 4;
 }
 
 message BaseHeaderProto {

--- a/src/rpc/RpcAuth.h
+++ b/src/rpc/RpcAuth.h
@@ -46,6 +46,12 @@ enum AuthProtocol {
     NONE = 0, SASL = -33
 };
 
+enum Protection {
+    AUTH = 1, // Authentication
+    INT = 2, // Integrity
+    CONF = 4 // Privacy
+};
+
 class RpcAuth {
 public:
     RpcAuth() :

--- a/src/rpc/RpcChannel.h
+++ b/src/rpc/RpcChannel.h
@@ -89,6 +89,8 @@ public:
      * Add reference count to this channel.
      */
     virtual void addRef() = 0;
+
+    virtual void Ping() = 0;
 };
 
 /**
@@ -140,6 +142,8 @@ public:
     void addRef() {
         ++refs;
     }
+
+    virtual void Ping();
 
 private:
     /**

--- a/src/rpc/RpcConfig.h
+++ b/src/rpc/RpcConfig.h
@@ -47,6 +47,7 @@ public:
         tcpNoDelay = conf.isRpcTcpNoDelay();
         lingerTimeout = conf.getRpcSocketLingerTimeout();
         rpcTimeout = conf.getRpcTimeout();
+        protection = conf.getRpcProtection();
     }
 
     size_t hash_value() const;
@@ -123,6 +124,10 @@ public:
         this->rpcTimeout = rpcTimeout;
     }
 
+    int getProtection() const {
+        return protection;
+    }
+
     bool operator ==(const RpcConfig & other) const {
         return this->maxIdleTime == other.maxIdleTime
                && this->pingTimeout == other.pingTimeout
@@ -132,7 +137,8 @@ public:
                && this->maxRetryOnConnect == other.maxRetryOnConnect
                && this->tcpNoDelay == other.tcpNoDelay
                && this->lingerTimeout == other.lingerTimeout
-               && this->rpcTimeout == other.rpcTimeout;
+               && this->rpcTimeout == other.rpcTimeout
+               && this->protection == other.protection;
     }
 
 private:
@@ -145,6 +151,7 @@ private:
     int lingerTimeout;
     int rpcTimeout;
     bool tcpNoDelay;
+    int protection;
 };
 
 }

--- a/src/rpc/SaslClient.cpp
+++ b/src/rpc/SaslClient.cpp
@@ -31,17 +31,177 @@
 #include "Exception.h"
 #include "ExceptionInternal.h"
 #include "SaslClient.h"
+#include <string>
+#include <sstream>
+#include <map>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+using boost::property_tree::ptree;
+using boost::property_tree::read_json;
+using boost::property_tree::write_json;
 
 #define SASL_SUCCESS 0
 
 namespace Hdfs {
 namespace Internal {
 
+std::string calculateIV(std::string initIV, long counter) {
+    std::string IV;
+    IV.resize(initIV.length());
+    int i = initIV.length();
+    int j = 0;
+    int sum = 0;
+    unsigned c;
+    while (i-- > 0) {
+      // (sum >>> Byte.SIZE) is the carry for addition
+      sum = (((unsigned char)initIV.c_str()[i]) & 0xff) + ((unsigned int)sum >> 8);
+      if (j++ < 8) { // Big-endian, and long is 8 bytes length
+        sum += (unsigned char) counter & 0xff;
+        c = (unsigned long) counter;
+        c >>= (unsigned)8;
+        counter = c;
+      }
+      IV[i] = (unsigned char) sum;
+    }
+    return IV;
+}
+
+void printArray(std::string str, const char* text) {
+    int i=0;
+    printf("length %d: %s\n", (int)str.length(), text);
+    for (i=0; i < (int)str.length(); i++) {
+        printf("%02d ", (int)str[i]);
+    }
+    printf("\n");
+
+}
+bool AESClient::initialized = false;
+
+AESClient::AESClient(std::string enckey, std::string enciv,
+              std::string deckey, std::string deciv, int bufsize) :
+              encrypt(NULL), decrypt(NULL), packetsSent(0), decoffset(0), bufsize(bufsize),
+              enckey(enckey), enciv(enciv), deckey(deckey), deciv(deciv), initdeciv(deciv)
+{
+    if (!initialized) {
+      ERR_load_crypto_strings();
+      OpenSSL_add_all_algorithms();
+      OPENSSL_config(NULL);
+      initialized = true;
+    }
+    encrypt = NULL;
+    decrypt = NULL;
+    encrypt = EVP_CIPHER_CTX_new();
+    if (!encrypt) {
+        std::string err = ERR_lib_error_string(ERR_get_error());
+        THROW(HdfsIOException, "Cannot initialize aes encrypt context %s",
+              err.c_str());
+    }
+    decrypt = EVP_CIPHER_CTX_new();
+    if (!decrypt) {
+        std::string err = ERR_lib_error_string(ERR_get_error());
+        THROW(HdfsIOException, "Cannot initialize aes decrypt context %s",
+              err.c_str());
+    }
+    std::string iv = enciv;
+    const EVP_CIPHER *cipher = NULL;
+    if (enckey.length() == 32)
+        cipher = EVP_aes_256_ctr();
+    else if (enckey.length() == 16)
+        cipher = EVP_aes_128_ctr();
+    else
+        cipher = EVP_aes_192_ctr();
+    if (!EVP_CipherInit_ex(encrypt, cipher, NULL,
+        (const unsigned char*)enckey.c_str(), (const unsigned char*)iv.c_str(), 1)) {
+        std::string err = ERR_lib_error_string(ERR_get_error());
+        THROW(HdfsIOException, "Cannot initialize aes encrypt cipher %s",
+              err.c_str());
+    }
+    iv = deciv;
+    if (!EVP_CipherInit_ex(decrypt, cipher, NULL, (const unsigned char*)deckey.c_str(),
+        (const unsigned char*)iv.c_str(), 0)) {
+        std::string err = ERR_lib_error_string(ERR_get_error());
+        THROW(HdfsIOException, "Cannot initialize aes decrypt cipher %s",
+              err.c_str());
+    }
+    EVP_CIPHER_CTX_set_padding(encrypt, 0);
+    EVP_CIPHER_CTX_set_padding(decrypt, 0);
+
+}
+
+AESClient::~AESClient() {
+    if (encrypt)
+        EVP_CIPHER_CTX_free(encrypt);
+    if (decrypt)
+        EVP_CIPHER_CTX_free(decrypt);
+}
+
+std::string AESClient::encode(const char *input, size_t input_len) {
+    int len;
+    std::string result;
+    result.resize(input_len);
+    int offset = 0;
+    int remaining = input_len;
+
+    while (remaining > bufsize) {
+        if (!EVP_CipherUpdate (encrypt, (unsigned char*)&result[offset], &len, (const unsigned char*)input+offset, bufsize)) {
+            std::string err = ERR_lib_error_string(ERR_get_error());
+            THROW(HdfsIOException, "Cannot encrypt AES data %s",
+                  err.c_str());
+        }
+        offset += len;
+        remaining -= len;
+    }
+    if (remaining) {
+
+        if (!EVP_CipherUpdate (encrypt, (unsigned char*)&result[offset], &len, (const unsigned char*)input+offset, remaining)) {
+            std::string err = ERR_lib_error_string(ERR_get_error());
+            THROW(HdfsIOException, "Cannot encrypt AES data %s",
+                  err.c_str());
+        }
+    }
+    return result;
+}
+
+
+std::string AESClient::decode(const char *input, size_t input_len) {
+    int len;
+    std::string result;
+    result.resize(input_len);
+    int offset = 0;
+    int remaining = input_len;
+
+    while (remaining > bufsize) {
+        if (!EVP_CipherUpdate (decrypt, (unsigned char*)&result[offset], &len, (const unsigned char*)input+offset, bufsize)) {
+            std::string err = ERR_lib_error_string(ERR_get_error());
+            THROW(HdfsIOException, "Cannot decrypt AES data %s",
+                  err.c_str());
+        }
+        offset += len;
+        remaining -= len;
+    }
+    if (remaining) {
+
+        if (!EVP_CipherUpdate (decrypt, (unsigned char*)&result[offset], &len, (const unsigned char*)input+offset, remaining)) {
+            std::string err = ERR_lib_error_string(ERR_get_error());
+            THROW(HdfsIOException, "Cannot decrypt AES data %s",
+                  err.c_str());
+        }
+    }
+    decoffset += input_len;
+    return result;
+
+}
+
+
+
+
 SaslClient::SaslClient(const RpcSaslProto_SaslAuth & auth, const Token & token,
-                       const std::string & principal) :
-     complete(false), changeLength(false),
+                       const std::string & principal, bool encryptedData, int protection) :
+     aes(NULL), ctx(NULL), session(NULL), changeLength(false), complete(false),
      privacy(false), integrity(false),
-     theAuth(auth), theToken(token), thePrincipal(principal)  {
+     theAuth(auth), theToken(token), thePrincipal(principal), encryptedData(encryptedData) ,
+       protection(protection) {
     int rc;
     ctx = NULL;
     RpcAuth method = RpcAuth(RpcAuth::ParseMethod(auth.method()));
@@ -67,6 +227,9 @@ SaslClient::SaslClient(const RpcSaslProto_SaslAuth & auth, const Token & token,
 }
 
 SaslClient::~SaslClient() {
+    if (aes)
+        delete aes;
+
     if (session != NULL) {
         gsasl_finish(session);
         session = NULL;
@@ -78,6 +241,17 @@ SaslClient::~SaslClient() {
     }
 }
 
+bool SaslClient::needsLength() {
+    if (aes != NULL)
+        return false;
+    if ((!privacy && !integrity) || (!complete))
+        return false;
+    return true;
+}
+
+void SaslClient::setAes(AESClient *client) {
+    aes = client;
+}
 
 void SaslClient::initKerberos(const RpcSaslProto_SaslAuth & auth,
                               const std::string & principal) {
@@ -101,6 +275,8 @@ std::string Base64Encode(const std::string & in) {
     int rc = gsasl_base64_to(in.c_str(), in.size(), &temp, &len);
 
     if (rc != GSASL_OK) {
+        if (rc == GSASL_BASE64_ERROR)
+            THROW(HdfsIOException, "SaslClient: Failed to encode string to base64");
         throw std::bad_alloc();
     }
 
@@ -116,6 +292,30 @@ std::string Base64Encode(const std::string & in) {
     return retval;
 }
 
+std::string Base64Decode(const std::string & in) {
+    char * temp;
+    size_t len;
+    std::string retval;
+    int rc = gsasl_base64_from(in.c_str(), in.size(), &temp, &len);
+
+    if (rc != GSASL_OK) {
+        if (rc == GSASL_BASE64_ERROR)
+            THROW(HdfsIOException, "SaslClient: Failed to decode string to base64");
+        throw std::bad_alloc();
+    }
+
+    if (temp) {
+        retval.assign(temp, len);
+        free(temp);
+    }
+
+    if (!temp || retval.length() != len) {
+        THROW(HdfsIOException, "SaslClient: Failed to decode string to base64");
+    }
+
+    return retval;
+}
+
 void SaslClient::initDigestMd5(const RpcSaslProto_SaslAuth & auth,
                                const Token & token) {
     int rc;
@@ -125,9 +325,14 @@ void SaslClient::initDigestMd5(const RpcSaslProto_SaslAuth & auth,
     }
 
     std::string password = Base64Encode(token.getPassword());
-    std::string identifier = Base64Encode(token.getIdentifier());
+    std::string identifier;
+
+    if (!encryptedData)
+        identifier = Base64Encode(token.getIdentifier());
+    else
+        identifier = token.getIdentifier();
     gsasl_property_set(session, GSASL_PASSWORD, password.c_str());
-    gsasl_property_set(session, GSASL_AUTHID, identifier.c_str());
+    gsasl_property_set_raw(session, GSASL_AUTHID, identifier.c_str(), identifier.length());
     gsasl_property_set(session, GSASL_HOSTNAME, auth.serverid().c_str());
     gsasl_property_set(session, GSASL_SERVICE, auth.protocol().c_str());
     changeLength = true;
@@ -149,6 +354,8 @@ std::string SaslClient::evaluateChallenge(const std::string & challenge) {
     char * output = NULL;
     size_t outputSize;
     std::string retval;
+    std::string copied_challenge = challenge;
+
     rc = gsasl_step(session, challenge.data(), challenge.size(), &output,
                     &outputSize);
     RpcAuth method = RpcAuth(RpcAuth::ParseMethod(theAuth.method()));
@@ -185,10 +392,15 @@ std::string SaslClient::evaluateChallenge(const std::string & challenge) {
                 preferred = qop[0];
         }
         else if (challenge.length()) {
-            std::string decoded = decode(challenge.c_str(), challenge.length());
-            int qop = (int)decoded.c_str()[0];
-            preferred = findPreferred(qop);
+            if (protection != 0)
+                preferred = protection;
+            else {
+                std::string decoded = decode(copied_challenge.c_str(), copied_challenge.length(), true);
+                int qop = (int)decoded.c_str()[0];
+                preferred = findPreferred(qop);
+            }
         }
+
         if (preferred & GSASL_QOP_AUTH_CONF) {
             privacy = true;
             integrity = true;
@@ -207,6 +419,8 @@ std::string SaslClient::encode(const char *input, size_t input_len) {
         memcpy((void *)result.data(), input, input_len);
         return result;
     }
+    if (aes)
+        return aes->encode(input, input_len);
 
     char *output=NULL;
     size_t output_len;
@@ -227,13 +441,17 @@ std::string SaslClient::encode(const char *input, size_t input_len) {
     return result;
 }
 
-std::string  SaslClient::decode(const char *input, size_t input_len) {
+
+std::string  SaslClient::decode(const char *input, size_t input_len, bool force) {
     std::string result;
-    if ((!privacy && !integrity) || (!complete)) {
+    if ((!privacy && !integrity && !force) || (!complete)) {
         result.resize(input_len);
         memcpy((void *)result.data(), input, input_len);
         return result;
     }
+    if (aes)
+        return aes->decode(input, input_len);
+
     char *output=NULL;
     size_t output_len;
     std::string actualInput;

--- a/src/server/Datanode.cpp
+++ b/src/server/Datanode.cpp
@@ -47,6 +47,23 @@ DatanodeImpl::DatanodeImpl(const std::string & host, uint32_t port,
     server.setTokenService("");
 }
 
+void DatanodeImpl::sendPing() {
+    RpcChannel & channel = client.getChannel(auth, protocol, server, conf);
+    try {
+        channel.Ping();
+    } catch (const HdfsFailoverException & e) {
+        //Datanode do not have HA configuration.
+        channel.close(true);
+        Hdfs::rethrow_if_nested(e);
+        assert(false && "HdfsFailoverException should be always a wrapper of other exception");
+    } catch (...) {
+        channel.close(true);
+        throw;
+    }
+
+    channel.close(false);
+}
+
 void DatanodeImpl::invoke(const RpcCall & call, bool reuse) {
     RpcChannel & channel = client.getChannel(auth, protocol, server, conf);
 

--- a/src/server/Datanode.h
+++ b/src/server/Datanode.h
@@ -81,6 +81,8 @@ public:
     virtual void getBlockLocalPathInfo(const ExtendedBlock & block,
                                        const Token & token, BlockLocalPathInfo & info)
     /*throw (HdfsIOException)*/ = 0;
+
+    virtual void sendPing() = 0;
 };
 
 class DatanodeImpl: public Datanode {
@@ -92,6 +94,8 @@ public:
 
     virtual void getBlockLocalPathInfo(const ExtendedBlock & block,
                                        const Token & token, BlockLocalPathInfo & info);
+
+    virtual void sendPing();
 
 private:
     void invoke(const RpcCall & call, bool reuse);

--- a/src/server/EncryptionKey.h
+++ b/src/server/EncryptionKey.h
@@ -1,0 +1,107 @@
+/********************************************************************
+ * Copyright (c) 2013 - 2014, Pivotal Inc.
+ * All rights reserved.
+ *
+ * Author: Zhanwei Wang
+ ********************************************************************/
+/********************************************************************
+ * 2014 -
+ * open source under Apache License Version 2.0
+ ********************************************************************/
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef _HDFS_LIBHDFS3_SERVER_ENCRYPTIONKEY_H_
+#define _HDFS_LIBHDFS3_SERVER_ENCRYPTIONKEY_H_
+
+#include <string>
+#include <sstream>
+
+namespace Hdfs {
+namespace Internal {
+
+/**
+ * Identifies an encryption Key
+ */
+class EncryptionKey {
+public:
+    EncryptionKey() :
+        keyId(0), expiryDate(0) {
+    }
+
+    int32_t getKeyId() const {
+        return keyId;
+    }
+
+    void setKeyId(int32_t keyId) {
+        this->keyId = keyId;
+    }
+
+    int64_t getExpiryDate() const {
+        return expiryDate;
+    }
+
+    void setExpiryDate(int64_t expiryDate) {
+        this->expiryDate = expiryDate;
+    }
+
+    const std::string & getBlockPoolId() const {
+        return blockPoolId;
+    }
+
+    void setBlockPoolId(const std::string & blockPoolId) {
+        this->blockPoolId = blockPoolId;
+    }
+
+    const std::string & getNonce() const {
+        return nonce;
+    }
+
+    void setNonce(const std::string & nonce) {
+        this->nonce = nonce;
+    }
+
+    const std::string & getEncryptionKey() const {
+        return encryptionKey;
+    }
+
+    void setEncryptionKey(const std::string & encryptionKey) {
+        this->encryptionKey = encryptionKey;
+    }
+
+    const std::string & getEncryptionAlgorithm() const {
+        return encryptionAlgorithm;
+    }
+
+    void setEncryptionAlgorithm(const std::string & encryptionAlgorithm) {
+        this->encryptionAlgorithm = encryptionAlgorithm;
+    }
+
+
+private:
+    int32_t keyId;
+    int64_t expiryDate;
+    std::string blockPoolId;
+    std::string nonce;
+    std::string encryptionKey;
+    std::string encryptionAlgorithm;
+};
+
+}
+}
+
+#endif /* _HDFS_LIBHDFS3_SERVER_ENCRYPTIONKEY_H_ */

--- a/src/server/Namenode.h
+++ b/src/server/Namenode.h
@@ -41,6 +41,7 @@
 #include "rpc/RpcConfig.h"
 #include "rpc/RpcProtocolInfo.h"
 #include "rpc/RpcServerInfo.h"
+#include "server/EncryptionKey.h"
 #include "SessionConfig.h"
 
 #include <vector>
@@ -55,6 +56,8 @@ public:
      */
     virtual ~Namenode() {
     }
+
+    virtual EncryptionKey getEncryptionKeys() = 0;
 
     /**
      * Get locations of the blocks of the specified file within the specified range.

--- a/src/server/NamenodeImpl.cpp
+++ b/src/server/NamenodeImpl.cpp
@@ -65,6 +65,30 @@ void NamenodeImpl::invoke(const RpcCall & call) {
     channel.close(false);
 }
 
+EncryptionKey NamenodeImpl::getEncryptionKeys()
+{
+    try {
+        GetDataEncryptionKeyRequestProto request;
+        GetDataEncryptionKeyResponseProto response;
+
+        invoke(RpcCall(true, "getDataEncryptionKey", &request, &response));
+        EncryptionKey key;
+        key.setKeyId(response.dataencryptionkey().keyid());
+        key.setExpiryDate(response.dataencryptionkey().expirydate());
+        key.setBlockPoolId(response.dataencryptionkey().blockpoolid());
+        key.setNonce(response.dataencryptionkey().nonce());
+        key.setEncryptionKey(response.dataencryptionkey().encryptionkey());
+        key.setEncryptionAlgorithm(response.dataencryptionkey().encryptionalgorithm());
+        return key;
+
+    } catch (const HdfsRpcServerException & e) {
+        UnWrapper < FileNotFoundException,
+                  UnresolvedLinkException, HdfsIOException > unwrapper(e);
+        unwrapper.unwrap(__FILE__, __LINE__);
+    }
+
+}
+
 //Idempotent
 void NamenodeImpl::getBlockLocations(const std::string & src, int64_t offset,
                                      int64_t length, LocatedBlocks & lbs) /* throw (AccessControlException,

--- a/src/server/NamenodeImpl.h
+++ b/src/server/NamenodeImpl.h
@@ -224,6 +224,8 @@ public:
     void cancelDelegationToken(const Token & token)
     /*throws IOException*/;
 
+    EncryptionKey getEncryptionKeys();
+
 private:
     void invoke(const RpcCall & call);
 

--- a/src/server/NamenodeProxy.cpp
+++ b/src/server/NamenodeProxy.cpp
@@ -246,6 +246,13 @@ void NamenodeProxy::getBlockLocations(const std::string & src, int64_t offset,
     NAMENODE_HA_RETRY_END();
 }
 
+EncryptionKey NamenodeProxy::getEncryptionKeys() {
+    EncryptionKey key;
+    NAMENODE_HA_RETRY_BEGIN();
+    return namenode->getEncryptionKeys();
+    NAMENODE_HA_RETRY_END();
+    return key;
+}
 void NamenodeProxy::create(const std::string & src, const Permission & masked,
                            const std::string & clientName, int flag, bool createParent,
                            short replication, int64_t blockSize) {
@@ -350,9 +357,11 @@ void NamenodeProxy::concat(const std::string & trg,
 
 bool NamenodeProxy::truncate(const std::string & src, int64_t size,
                              const std::string & clientName) {
+    bool ret = false;
     NAMENODE_HA_RETRY_BEGIN();
     return namenode->truncate(src, size, clientName);
     NAMENODE_HA_RETRY_END();
+    return ret;
 }
 
 void NamenodeProxy::getLease(const std::string & src,

--- a/src/server/NamenodeProxy.h
+++ b/src/server/NamenodeProxy.h
@@ -44,6 +44,8 @@ public:
 
 public:
 
+    EncryptionKey getEncryptionKeys();
+
     void getBlockLocations(const std::string & src, int64_t offset,
                            int64_t length, LocatedBlocks & lbs);
 


### PR DESCRIPTION
Changelog category:
New Feature

Changelog entry:
Makes libhdfs3 support secure datanode data transfer

Currenty, Clickhouse doesn't support dfs.data.transfer.protection=privacy. There're 2 parts need to modify. This is the first  part.