### PR TITLE
Fix the problem that a node crashes when a common cluster accesses HDFS.

### DIFF
--- a/src/rpc/RpcChannel.cpp
+++ b/src/rpc/RpcChannel.cpp
@@ -617,9 +617,13 @@ void RpcChannelImpl::sendRequest(RpcRemoteCallPtr remote) {
     if (saslClient) {
         SaslOutputWrapper wrapper(saslClient.get(), &client);
         data = wrapper.wrap(&buffer);
+        sock->writeFully(data->getBuffer(0), data->getDataSize(0),
+                        key.getConf().getWriteTimeout());
+    } else {
+        sock->writeFully(buffer.getBuffer(0), buffer.getDataSize(0),
+                        key.getConf().getWriteTimeout());
     }
-    sock->writeFully(data->getBuffer(0), data->getDataSize(0),
-                     key.getConf().getWriteTimeout());
+
     uint32_t id = remote->getIdentity();
     pendingCalls[id] = remote;
     lastActivity = lastIdle = steady_clock::now();
@@ -681,9 +685,13 @@ void RpcChannelImpl::sendPing() {
         if (saslClient) {
             SaslOutputWrapper wrapper(saslClient.get(), &client);
             data = wrapper.wrap(pingRequest);
+            sock->writeFully(data->getBuffer(0), data->getDataSize(0),
+                    key.getConf().getWriteTimeout());
+        } else {
+            sock->writeFully(pingRequest->getBuffer(0), pingRequest->getDataSize(0),
+                    key.getConf().getWriteTimeout());
         }
-        sock->writeFully(data->getBuffer(0), data->getDataSize(0),
-                key.getConf().getWriteTimeout());
+
         lastActivity = steady_clock::now();
     }
 }
@@ -796,10 +804,13 @@ void RpcChannelImpl::sendConnectionContent(const RpcAuth & auth) {
     if (saslClient) {
         SaslOutputWrapper wrapper(saslClient.get(), &client);
         data = wrapper.wrap(&buffer);
+        sock->writeFully(data->getBuffer(0), data->getDataSize(0),
+                        key.getConf().getWriteTimeout());
+    } else {
+        sock->writeFully(buffer.getBuffer(0), buffer.getDataSize(0),
+                        key.getConf().getWriteTimeout());
     }
 
-    sock->writeFully(data->getBuffer(0), data->getDataSize(0),
-                     key.getConf().getWriteTimeout());
     lastActivity = lastIdle = steady_clock::now();
 }
 


### PR DESCRIPTION
One changes:
1. Fix the problem that a node crashes when a common cluster accesses HDFS.

Close https://github.com/ClickHouse/ClickHouse/issues/41098