### PR TITLE
Fix concurrent read causing high System CPU

### DIFF
--- a/src/client/InputStreamImpl.cpp
+++ b/src/client/InputStreamImpl.cpp
@@ -601,7 +601,7 @@ int32_t InputStreamImpl::readInternal(char * buf, int32_t size) {
                  * Check if we reach the end of file.
                  */
                 if (cursor >= getFileLength()) {
-                    THROW(HdfsEndOfStream,
+                    THROW_NO_STACK(HdfsEndOfStream,
                           "InputStreamImpl: read over EOF, current position: %" PRId64 ", read size: %d, from file: %s",
                           cursor, size, path.c_str());
                 }
@@ -696,7 +696,7 @@ void InputStreamImpl::readFullyInternal(char * buf, int64_t size) {
     } catch (const HdfsCanceled & e) {
         throw;
     } catch (const HdfsEndOfStream & e) {
-        THROW(HdfsEndOfStream,
+        THROW_NO_STACK(HdfsEndOfStream,
               "InputStreamImpl: read over EOF, current position: %" PRId64 ", read size: %" PRId64 ", from file: %s",
               pos, size, path.c_str());
     } catch (const HdfsException & e) {
@@ -746,7 +746,7 @@ void InputStreamImpl::seekInternal(int64_t pos) {
         updateBlockInfos();
 
         if (pos > getFileLength()) {
-            THROW(HdfsEndOfStream,
+            THROW_NO_STACK(HdfsEndOfStream,
                   "InputStreamImpl: seek over EOF, current position: %" PRId64 ", seek target: %" PRId64 ", in file: %s",
                   cursor, pos, path.c_str());
         }

--- a/src/common/ExceptionInternal.h
+++ b/src/common/ExceptionInternal.h
@@ -202,12 +202,12 @@ namespace Internal {
 
 template<typename THROWABLE>
 ATTRIBUTE_NORETURN ATTRIBUTE_NOINLINE
-void ThrowException(bool nested, const char * f, int l,
-                    const char * exceptionName, const char * fmt, ...) __attribute__((format(printf, 5, 6)));
+void ThrowException(bool nested, bool printStack, const char * f, int l,
+                    const char * exceptionName, const char * fmt, ...) __attribute__((format(printf, 6, 7)));
 
 template<typename THROWABLE>
 ATTRIBUTE_NORETURN ATTRIBUTE_NOINLINE
-void ThrowException(bool nested, const char * f, int l,
+void ThrowException(bool nested, bool printStack, const char * f, int l,
                     const char * exceptionName, const char * fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
@@ -224,11 +224,11 @@ void ThrowException(bool nested, const char * f, int l,
 
     if (!nested) {
         throw THROWABLE(buffer.c_str(), SkipPathPrefix(f), l,
-                        Hdfs::Internal::PrintStack(1, STACK_DEPTH).c_str());
+                        printStack ? Hdfs::Internal::PrintStack(1, STACK_DEPTH).c_str() : "");
     } else {
         Hdfs::throw_with_nested(
             THROWABLE(buffer.c_str(), SkipPathPrefix(f), l,
-                      Hdfs::Internal::PrintStack(1, STACK_DEPTH).c_str()));
+                      printStack ? Hdfs::Internal::PrintStack(1, STACK_DEPTH).c_str() : ""));
     }
 
     throw std::logic_error("should not reach here.");
@@ -292,9 +292,12 @@ const char * GetSystemErrorInfo(int eno);
 }
 
 #define THROW(throwable, fmt, ...) \
-    Hdfs::Internal::ThrowException<throwable>(false, __FILE__, __LINE__, #throwable, fmt, ##__VA_ARGS__);
+    Hdfs::Internal::ThrowException<throwable>(false, true, __FILE__, __LINE__, #throwable, fmt, ##__VA_ARGS__);
 
 #define NESTED_THROW(throwable, fmt, ...) \
-    Hdfs::Internal::ThrowException<throwable>(true, __FILE__, __LINE__, #throwable, fmt, ##__VA_ARGS__);
+    Hdfs::Internal::ThrowException<throwable>(true, true, __FILE__, __LINE__, #throwable, fmt, ##__VA_ARGS__);
+
+#define THROW_NO_STACK(throwable, fmt, ...) \
+    Hdfs::Internal::ThrowException<throwable>(false, false, __FILE__, __LINE__, #throwable, fmt, ##__VA_ARGS__);
 
 #endif /* _HDFS_LIBHDFS3_EXCEPTION_EXCEPTIONINTERNAL_H_ */

--- a/src/network/DomainSocket.cpp
+++ b/src/network/DomainSocket.cpp
@@ -137,13 +137,13 @@ int32_t DomainSocketImpl::receiveFileDescriptors(int fds[], size_t nfds,
   }
 
   if (0 == rc) {
-    THROW(HdfsEndOfStream,
+    THROW_NO_STACK(HdfsEndOfStream,
           "Read file descriptors failed from %s: End of the stream",
           remoteAddr.c_str());
   }
 
   if (msg.msg_controllen != cmsg->cmsg_len) {
-    THROW(HdfsEndOfStream, "Read file descriptors failed from %s.",
+    THROW_NO_STACK(HdfsEndOfStream, "Read file descriptors failed from %s.",
           remoteAddr.c_str());
   }
 

--- a/src/network/TcpSocket.cpp
+++ b/src/network/TcpSocket.cpp
@@ -76,7 +76,7 @@ int32_t TcpSocketImpl::read(char * buffer, int32_t size) {
     }
 
     if (0 == rc) {
-        THROW(HdfsEndOfStream, "Read %d bytes failed from %s: End of the stream", size, remoteAddr.c_str());
+        THROW_NO_STACK(HdfsEndOfStream, "Read %d bytes failed from %s: End of the stream", size, remoteAddr.c_str());
     }
 
     return rc;


### PR DESCRIPTION
Fix concurrent read causing high System CPU, by avoiding the print stack of the HdfsEndOfStream exception.

Close https://github.com/ClickHouse/ClickHouse/issues/41525
