### PR TITLE
optimize hdfs seek

### DIFF
--- a/src/client/InputStreamImpl.cpp
+++ b/src/client/InputStreamImpl.cpp
@@ -753,7 +753,7 @@ void InputStreamImpl::seekInternal(int64_t pos) {
     }
 
     try {
-        if (blockReader && pos > cursor && pos < endOfCurBlock) {
+        if (blockReader && pos > cursor && pos < endOfCurBlock && pos - cursor <= 128 * 1024) {
             blockReader->skip(pos - cursor);
             cursor = pos;
             return;


### PR DESCRIPTION
After optimizing the hdfs seek method,  if the target of the seek method exceeds a certain length, the blockReader's skip method will not be called again to prevent frequent calls to the readNextPacket method, thus improving the performance of the seek method.