### PR TITLE
Changes to support the HDFS in PowerPC

### DIFF
--- a/src/client/LocalBlockReader.cpp
+++ b/src/client/LocalBlockReader.cpp
@@ -85,11 +85,14 @@ LocalBlockReader::LocalBlockReader(const shared_ptr<ReadShortCircuitInfo>& info,
         case ChecksumTypeProto::CHECKSUM_CRC32:
         case ChecksumTypeProto::CHECKSUM_CRC32C:
 #if defined(__SSE4_2__) && defined(__LP64__)
+#if !((defined(__PPC64__) || defined(__powerpc64__)) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
             checksum = std::make_shared<IntelAsmCrc32c>();
 #else
             if (HWCrc32c::available()) {
                 checksum = shared_ptr<Checksum>(new HWCrc32c());
-            } else {
+            } else
+#endif
+            {
                 checksum = shared_ptr<Checksum>(new SWCrc32c());
             }
 #endif

--- a/src/client/LocalBlockReader.cpp
+++ b/src/client/LocalBlockReader.cpp
@@ -85,9 +85,9 @@ LocalBlockReader::LocalBlockReader(const shared_ptr<ReadShortCircuitInfo>& info,
         case ChecksumTypeProto::CHECKSUM_CRC32:
         case ChecksumTypeProto::CHECKSUM_CRC32C:
 #if defined(__SSE4_2__) && defined(__LP64__)
-#if !((defined(__PPC64__) || defined(__powerpc64__)) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
             checksum = std::make_shared<IntelAsmCrc32c>();
 #else
+#if !((defined(__PPC64__) || defined(__powerpc64__)) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
             if (HWCrc32c::available()) {
                 checksum = shared_ptr<Checksum>(new HWCrc32c());
             } else

--- a/src/client/OutputStreamImpl.cpp
+++ b/src/client/OutputStreamImpl.cpp
@@ -55,9 +55,12 @@ OutputStreamImpl::OutputStreamImpl() :
 #if defined(__SSE4_2__) && defined(__LP64__)
     checksum = std::make_shared<IntelAsmCrc32c>();
 #else
+#if !((defined(__PPC64__) || defined(__powerpc64__)) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
     if (HWCrc32c::available()) {
         checksum = shared_ptr < Checksum > (new HWCrc32c());
-    } else {
+    } else
+#endif
+    {
         checksum = shared_ptr < Checksum > (new SWCrc32c());
     }
 #endif

--- a/src/client/RemoteBlockReader.cpp
+++ b/src/client/RemoteBlockReader.cpp
@@ -196,9 +196,12 @@ void RemoteBlockReader::checkResponse() {
 #if defined(__SSE4_2__) && defined(__LP64__)
         checksum = std::make_shared<IntelAsmCrc32c>();
 #else
+#if !((defined(__PPC64__) || defined(__powerpc64__)) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
         if (HWCrc32c::available()) {
             checksum = shared_ptr<Checksum>(new HWCrc32c());
-        } else {
+        } else
+#endif
+        {
             checksum = shared_ptr<Checksum>(new SWCrc32c());
         }
 #endif

--- a/src/common/HWCrc32c.cpp
+++ b/src/common/HWCrc32c.cpp
@@ -93,6 +93,7 @@ bool HWCrc32c::available() {
 #endif
 }
 
+#if !((defined(__ppc__) || defined(__powerpc64__)) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
 void HWCrc32c::update(const void * b, int len) {
     const char * p = static_cast<const char *>(b);
 #if defined(__LP64__)
@@ -164,5 +165,6 @@ void HWCrc32c::updateInt64(const char * b, int len) {
     }
 }
 
+#endif
 }
 }

--- a/src/rpc/RpcChannel.cpp
+++ b/src/rpc/RpcChannel.cpp
@@ -617,9 +617,12 @@ void RpcChannelImpl::sendRequest(RpcRemoteCallPtr remote) {
     if (saslClient) {
         SaslOutputWrapper wrapper(saslClient.get(), &client);
         data = wrapper.wrap(&buffer);
+        sock->writeFully(data->getBuffer(0), data->getDataSize(0),
+                          key.getConf().getWriteTimeout());
+     } else {
+          sock->writeFully(buffer.getBuffer(0), buffer.getDataSize(0),
+                          key.getConf().getWriteTimeout());
     }
-    sock->writeFully(data->getBuffer(0), data->getDataSize(0),
-                     key.getConf().getWriteTimeout());
     uint32_t id = remote->getIdentity();
     pendingCalls[id] = remote;
     lastActivity = lastIdle = steady_clock::now();
@@ -681,9 +684,12 @@ void RpcChannelImpl::sendPing() {
         if (saslClient) {
             SaslOutputWrapper wrapper(saslClient.get(), &client);
             data = wrapper.wrap(pingRequest);
+            sock->writeFully(data->getBuffer(0), data->getDataSize(0),
+                      key.getConf().getWriteTimeout());
+         } else {
+              sock->writeFully(pingRequest->getBuffer(0), pingRequest->getDataSize(0),
+                      key.getConf().getWriteTimeout());
         }
-        sock->writeFully(data->getBuffer(0), data->getDataSize(0),
-                key.getConf().getWriteTimeout());
         lastActivity = steady_clock::now();
     }
 }
@@ -796,10 +802,13 @@ void RpcChannelImpl::sendConnectionContent(const RpcAuth & auth) {
     if (saslClient) {
         SaslOutputWrapper wrapper(saslClient.get(), &client);
         data = wrapper.wrap(&buffer);
+        sock->writeFully(data->getBuffer(0), data->getDataSize(0),
+                          key.getConf().getWriteTimeout());
+     } else {
+          sock->writeFully(buffer.getBuffer(0), buffer.getDataSize(0),
+                          key.getConf().getWriteTimeout());
     }
 
-    sock->writeFully(data->getBuffer(0), data->getDataSize(0),
-                     key.getConf().getWriteTimeout());
     lastActivity = lastIdle = steady_clock::now();
 }
 


### PR DESCRIPTION
Enable the HDFS support in PowerPC and which helps to fixes the following functional tests 02113_hdfs_assert.sh, 02244_hdfs_cluster.sql and 02368_cancel_write_into_hdfs.sh.