### PR TITLE
Fix checking error caused by uninitialized class members

### DIFF
--- a/src/client/StripedBlockUtil.h
+++ b/src/client/StripedBlockUtil.h
@@ -50,13 +50,14 @@ public:
     public:
 	    VerticalRange() :offsetInBlock(0), spanInBlock(0) {}
         VerticalRange(long offset, long length) {
+            offsetInBlock = offset;
+            spanInBlock = length;
+
             std::stringstream ss;
             ss << "offsetInBlock=" + std::to_string(offset)
                << " length=" + std::to_string(length)
                << " must be non-negative.";
             Preconditions::checkArgument(offset >= 0 && length >= 0, ss.str());
-            offsetInBlock = offset;
-            spanInBlock = length;
         }
 
 	    void setOffsetInBlock(long offset) {
@@ -126,13 +127,14 @@ public:
 
     public:
         StripeRange(long offsetInBlock_, long length_) {
+            offsetInBlock = offsetInBlock_;
+            length = length_;
+
             std::stringstream ss;
             ss << "offsetInBlock=" + std::to_string(offsetInBlock)
                 << " length=" + std::to_string(length)
                 << " must be non-negative.";
             Preconditions::checkArgument(offsetInBlock >= 0 && length >= 0, ss.str());
-            offsetInBlock = offsetInBlock_;
-            length = length_;
         }
 
         bool include(long pos) {
@@ -252,7 +254,7 @@ public:
                 if (chunks[i] != nullptr) {
                     delete chunks[i];
                     chunks[i] = nullptr;
-                }    
+                }
             }
 
             if (range != nullptr) {
@@ -381,11 +383,12 @@ public:
 
     public:
         StripingChunkReadResult(int state_) {
-            Preconditions::checkArgument(state == TIMEOUT,
-                "Only timeout result should return negative index.");
             index = -1;
             state = state_;
             readStats = nullptr;
+
+            Preconditions::checkArgument(state == TIMEOUT,
+                "Only timeout result should return negative index.");
         }
 
         StripingChunkReadResult(int index, int state) {
@@ -393,11 +396,12 @@ public:
         }
 
         StripingChunkReadResult(int index_, int state_, BlockReadStats * stats_) {
-            Preconditions::checkArgument(state != TIMEOUT,
-                "Timeout result should return negative index.");
             index = index_;
             state = state_;
             readStats = stats_;
+
+            Preconditions::checkArgument(state != TIMEOUT,
+                "Timeout result should return negative index.");
         }
 
         BlockReadStats * getReadStats() const {
@@ -439,7 +443,7 @@ public:
     static long offsetInBlkToOffsetInBG(int cellSize, int dataBlkNum,
         long offsetInBlk, int idxInBlockGroup);
 
-    static void parseStripedBlockGroup(LocatedBlock & bg, int32_t cellSize, 
+    static void parseStripedBlockGroup(LocatedBlock & bg, int32_t cellSize,
         int32_t dataBlkNum, int32_t parityBlkNum, std::vector<LocatedBlock> & lbs);
 
 private:
@@ -466,14 +470,14 @@ private:
     }
 
     static void mergeRangesForInternalBlocks(shared_ptr<ECPolicy> ecPolicy,
-        std::vector<VerticalRange> & ranges, LocatedBlock & blockGroup, 
+        std::vector<VerticalRange> & ranges, LocatedBlock & blockGroup,
         int cellSize, std::vector<AlignedStripe*> & stripes);
 
     static void prepareAllZeroChunks(LocatedBlock & blockGroup,
         std::vector<AlignedStripe*> & stripes, int cellSize, int dataBlkNum);
-    
+
 };
-        
+
 }
 }
 


### PR DESCRIPTION
Fixed the error when reading hdfs ec files, it was caused by checking uninitialized class members in some construction functions
```
$ ./build_gcc/utils/extern-local-engine/examples/read_hive_text     
std::exception. Code: 1001, type: Hdfs::InvalidParameter, e.what() = InvalidParameter: offsetInBlock=-4702111234474983746 length=-4702111234474983746 must be non-negative., Stack trace (when copying this message, always include the lines below):

0. ./build_gcc/./contrib/llvm-project/libcxx/include/exception:134: std::runtime_error::runtime_error(String const&) @ 0x000000003cac92cd in /data1/liyang/cppproject/kyli/ClickHouse/build_gcc/utils/extern-local-engine/examples/read_hive_text
1. ./build_gcc/./contrib/libhdfs3/src/common/Exception.cpp:91: Hdfs::HdfsException::HdfsException(String const&, char const*, int, char const*) @ 0x000000002ffc76ef in /data1/liyang/cppproject/kyli/ClickHouse/build_gcc/utils/extern-local-engine/examples/read_hive_text
2. ./build_gcc/./contrib/libhdfs3/src/common/Exception.h:0: void Hdfs::Internal::ThrowException<Hdfs::InvalidParameter>(bool, bool, char const*, int, char const*, char const*, ...) @ 0x000000002fe16c34 in /data1/liyang/cppproject/kyli/ClickHouse/build_gcc/utils/extern-local-engine/examples/read_hive_text
3. ./build_gcc/./contrib/llvm-project/libcxx/include/string:1499: Hdfs::Internal::Preconditions::checkArgument(bool, String) @ 0x000000002feed88b in /data1/liyang/cppproject/kyli/ClickHouse/build_gcc/utils/extern-local-engine/examples/read_hive_text
4. ./build_gcc/./contrib/llvm-project/libcxx/include/string:1499: Hdfs::Internal::StripedBlockUtil::StripeRange::StripeRange(long, long) @ 0x000000002fed83bd in /data1/liyang/cppproject/kyli/ClickHouse/build_gcc/utils/extern-local-engine/examples/read_hive_text
5. ./build_gcc/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:460: Hdfs::Internal::StripedInputStreamImpl::StripedInputStreamImpl(std::shared_ptr<Hdfs::Internal::LocatedBlocks>) @ 0x000000002fed092a in /data1/liyang/cppproject/kyli/ClickHouse/build_gcc/utils/extern-local-engine/examples/read_hive_text
6. ./build_gcc/./contrib/libhdfs3/src/client/InputStream.cpp:0: Hdfs::InputStream::InputStream(std::shared_ptr<Hdfs::Internal::LocatedBlocks>) @ 0x000000002fe1efb2 in /data1/liyang/cppproject/kyli/ClickHouse/build_gcc/utils/extern-local-engine/examples/read_hive_text
7. ./build_gcc/./contrib/libhdfs3/src/client/Hdfs.cpp:0: hdfsOpenFile @ 0x000000002fe0801c in /data1/liyang/cppproject/kyli/ClickHouse/build_gcc/utils/extern-local-engine/examples/read_hive_text
8. ./build_gcc/./src/Storages/HDFS/ReadBufferFromHDFS.cpp:0: DB::ReadBufferFromHDFS::ReadBufferFromHDFSImpl::ReadBufferFromHDFSImpl(String const&, String const&, Poco::Util::AbstractConfiguration const&, DB::ReadSettings const&, unsigned long, bool) @ 0x0000000028c63ffb in /data1/liyang/cppproject/kyli/ClickHouse/build_gcc/utils/extern-local-engine/examples/read_hive_text
9. ./build_gcc/./src/Storages/HDFS/ReadBufferFromHDFS.cpp:162: DB::ReadBufferFromHDFS::ReadBufferFromHDFS(String const&, String const&, Poco::Util::AbstractConfiguration const&, DB::ReadSettings const&, unsigned long, bool) @ 0x0000000028c617ec in /data1/liyang/cppproject/kyli/ClickHouse/build_gcc/utils/extern-local-engine/examples/read_hive_text
10. ./build_gcc/./utils/extern-local-engine/examples/read_hive_text.cpp:25: main @ 0x000000000a060d06 in /data1/liyang/cppproject/kyli/ClickHouse/build_gcc/utils/extern-local-engine/examples/read_hive_text
11. __libc_start_main @ 0x00007fc315c320b3 in ?
12. _start @ 0x0000000009f9f3ee in /data1/liyang/cppproject/kyli/ClickHouse/build_gcc/utils/extern-local-engine/examples/read_hive_text
 (version 23.6.1.1)

```