### PR TITLE
libhdfs3: add log for slow read

### DIFF
--- a/src/common/DateTime.h
+++ b/src/common/DateTime.h
@@ -73,6 +73,12 @@ static int64_t ToMilliSeconds(TimeStamp const & s, TimeStamp const & e) {
     return duration_cast<milliseconds>(e - s).count();
 }
 
+template<typename Timestamp>
+static int64_t ToMicroSeconds(Timestamp const & s, Timestamp const & e) {
+    assert(e >= s);
+    return duration_cast<microseconds>(e - s).count();
+}
+
 }
 }
 

--- a/src/common/SessionConfig.cpp
+++ b/src/common/SessionConfig.cpp
@@ -134,6 +134,8 @@ SessionConfig::SessionConfig(const Config & conf) {
             &socketCacheCapacity, "dfs.client.socketcache.capacity", 16, bind(CheckRangeGE<int32_t>, _1, _2, 0)
         }, {
             &stripeReaderThreadPoolSize, "dfs.client.read.striped.thread-pool.size", 64
+        }, {
+            &slowReadThresholdMs, "dfs.client.slow.read.threshold.ms", 300
         }
     };
     ConfigDefault<int64_t> i64Values [] = {

--- a/src/common/SessionConfig.h
+++ b/src/common/SessionConfig.h
@@ -311,6 +311,10 @@ public:
         return stripeReaderThreadPoolSize;
     }
 
+    int32_t getSlowReadThresholdUs() const {
+        return slowReadThresholdMs * 1000;
+    }
+
 public:
     /*
      * rpc configure
@@ -356,6 +360,7 @@ public:
     int32_t socketCacheExpiry;
     std::string domainSocketPath;
     int32_t stripeReaderThreadPoolSize;
+    int32_t slowReadThresholdMs;
 
     /*
      * OutputStream configure


### PR DESCRIPTION
Add log for slow read and we can get the duration of each read operation by opening debug logs.
![image](https://github.com/ClickHouse/libhdfs3/assets/2844826/4565cd89-5644-40a8-95c4-0fdda7f54285)


