### PR TITLE
PR-1. Shuffle the namenodes in the NamenodeProxy

### DIFF
--- a/src/server/NamenodeProxy.h
+++ b/src/server/NamenodeProxy.h
@@ -155,7 +155,7 @@ private:
     int maxNamenodeHARetry;
     mutex mut;
     std::string clusterid;
-    std::vector<shared_ptr<Namenode> > namenodes;
+    std::vector<shared_ptr<Namenode>> namenodes;
     uint32_t currentNamenode;
 };
 


### PR DESCRIPTION
- There is no need to store the active namenode index in the local file
- We just need to shuffle the namenodes so that libhdfs3 can support ObserverRead in the future