### PR TITLE
[Feature] Add positional read for client

### DIFF
--- a/src/client/Hdfs.cpp
+++ b/src/client/Hdfs.cpp
@@ -842,6 +842,25 @@ tSize hdfsRead(hdfsFS fs, hdfsFile file, void * buffer, tSize length) {
     return -1;
 }
 
+tSize hdfsPread(hdfsFS fs, hdfsFile file, void * buffer, tSize length, tOffset position) {
+    PARAMETER_ASSERT(fs && file && buffer && length > 0 && position >= 0, -1, EINVAL);
+    PARAMETER_ASSERT(file->isInput(), -1, EINVAL);
+
+    try {
+        return file->getInputStream().pread(static_cast<char *>(buffer), length, position);
+    } catch (const Hdfs::HdfsEndOfStream & e) {
+        return 0;
+    } catch (const std::bad_alloc & e) {
+        SetErrorMessage("Out of memory");
+        errno = ENOMEM;
+    } catch (...) {
+        SetLastException(Hdfs::current_exception());
+        handleException(Hdfs::current_exception());
+    }
+
+    return -1;
+}
+
 tSize hdfsWrite(hdfsFS fs, hdfsFile file, const void * buffer, tSize length) {
     PARAMETER_ASSERT(fs && file && buffer && length > 0, -1, EINVAL);
     PARAMETER_ASSERT(!file->isInput(), -1, EINVAL);

--- a/src/client/InputStream.cpp
+++ b/src/client/InputStream.cpp
@@ -78,6 +78,17 @@ int32_t InputStream::read(char * buf, int32_t size) {
 }
 
 /**
+ * To read data from hdfs.
+ * @param buf the buffer used to filled.
+ * @param size buffer size.
+ * @param position the position to seek.
+ * @return return the number of bytes filled in the buffer, it may less than size.
+ */
+int32_t InputStream::pread(char * buf, int32_t size, int64_t position) {
+    return impl->pread(buf, size, position);
+}
+
+/**
  * To read data from hdfs, block until get the given size of bytes.
  * @param buf the buffer used to filled.
  * @param size the number of bytes to be read.

--- a/src/client/InputStream.h
+++ b/src/client/InputStream.h
@@ -63,6 +63,15 @@ public:
     int32_t read(char * buf, int32_t size);
 
     /**
+    * To read data from hdfs.
+    * @param buf the buffer used to filled.
+    * @param size buffer size.
+    * @param position the position to seek.
+    * @return return the number of bytes filled in the buffer, it may less than size.
+    */
+    int32_t pread(char * buf, int32_t size, int64_t position);
+
+    /**
      * To read data from hdfs, block until get the given size of bytes.
      * @param buf the buffer used to filled.
      * @param size the number of bytes to be read.

--- a/src/client/InputStreamInter.h
+++ b/src/client/InputStreamInter.h
@@ -64,6 +64,15 @@ public:
     virtual int32_t read(char * buf, int32_t size) = 0;
 
     /**
+     * To read data from hdfs.
+     * @param buf the buffer used to filled.
+     * @param size buffer size.
+     * @param position the position to seek.
+     * @return return the number of bytes filled in the buffer, it may less than size.
+     */
+    virtual int32_t pread(char * buf, int32_t size, int64_t position) = 0;
+
+    /**
      * To read data from hdfs, block until get the given size of bytes.
      * @param buf the buffer used to filled.
      * @param size the number of bytes to be read.

--- a/src/client/StripedInputStreamImpl.cpp
+++ b/src/client/StripedInputStreamImpl.cpp
@@ -153,7 +153,7 @@ const DatanodeInfo * StripedInputStreamImpl::choseBestNode(LocatedBlock & lb) {
     const std::vector<DatanodeInfo> & nodes = lb.getLocations();
 
     for (size_t i = 0; i < nodes.size(); ++i) {
-        if (std::binary_search(failedNodes.begin(), failedNodes.end(), nodes[i])) {
+        if (failedNodes.binary_search(nodes[i])) {
             continue;
         }
 
@@ -230,7 +230,7 @@ bool StripedInputStreamImpl::createBlockReader(LocatedBlock & block,
                     block.toString().c_str(), path.c_str(),
                     node->formatAddress().c_str(), GetExceptionDetail(e, buffer));
                 failedNodes.push_back(*node);
-                std::sort(failedNodes.begin(), failedNodes.end());
+                failedNodes.sort();
             }
 
             continue;

--- a/src/client/hdfs.h
+++ b/src/client/hdfs.h
@@ -374,6 +374,23 @@ tOffset hdfsTell(hdfsFS fs, hdfsFile file);
 tSize hdfsRead(hdfsFS fs, hdfsFile file, void * buffer, tSize length);
 
 /**
+ * hdfsRead - Positional read data from an open file.
+ * @param fs The configured filesystem handle.
+ * @param file The file handle.
+ * @param buffer The buffer to copy read bytes into.
+ * @param length The length of the buffer.
+ * @param position The position in the input stream to seek
+ * @return      On success, a positive number indicating how many bytes
+ *              were read.
+ *              On end-of-file, 0.
+ *              On error, -1.  Errno will be set to the error code.
+ *              Just like the POSIX read function, hdfsRead will return -1
+ *              and set errno to EINTR if data is temporarily unavailable,
+ *              but we are not yet at the end of the file.
+ */
+tSize hdfsPread(hdfsFS fs, hdfsFile file, void * buffer, tSize length, tOffset position);
+
+/**
  * hdfsWrite - Write data into an open file.
  * @param fs The configured filesystem handle.
  * @param file The file handle.

--- a/src/common/LockVector.h
+++ b/src/common/LockVector.h
@@ -1,0 +1,69 @@
+/********************************************************************
+ * 2024 -
+ * open source under Apache License Version 2.0
+ ********************************************************************/
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef _HDFS_LIBHDFS3_COMMON_LOCKVECTOR_H_
+#define _HDFS_LIBHDFS3_COMMON_LOCKVECTOR_H_
+
+#include <mutex>
+#include <vector>
+
+namespace Hdfs {
+namespace Internal {
+
+template<typename T>
+class LockVector{
+    std::mutex mlock;
+    std::vector<T> mvec;
+
+public:
+    void push_back(const T& value) {
+        std::lock_guard<std::mutex> lock(mlock);
+        mvec.push_back(value);
+    }
+
+    void clear() {
+        std::lock_guard<std::mutex> lock(mlock);
+        mvec.clear();
+    }
+
+    void sort() {
+        std::lock_guard<std::mutex> lock(mlock);
+        std::sort(mvec.begin(), mvec.end());
+    }
+
+    bool binary_search(const T &value) {
+        std::lock_guard<std::mutex> lock(mlock);
+        return std::binary_search(mvec.begin(), mvec.end(), value);
+    }
+
+    const std::vector<T>& get(){
+        return mvec;
+    }
+
+    void set(std::vector<T> &vec) {
+        mvec = vec;
+    }
+
+};
+
+}
+}
+#endif //_HDFS_LIBHDFS3_COMMON_LOCKVECTOR_H_

--- a/src/server/LocatedBlock.h
+++ b/src/server/LocatedBlock.h
@@ -45,11 +45,11 @@ namespace Internal {
 class LocatedBlock: public ExtendedBlock {
 public:
     LocatedBlock() :
-        offset(0), corrupt(false), striped(false) {
+        offset(0), corrupt(false), striped(false), lastBlock(false) {
     }
 
     LocatedBlock(int64_t position) :
-        offset(position), corrupt(false), striped(false) {
+        offset(position), corrupt(false), striped(false), lastBlock(false) {
     }
 
     bool isCorrupt() const {
@@ -124,12 +124,21 @@ public:
         return tokens;
     }
 
+    void setLastBlock(bool isLastBlock) {
+        lastBlock = isLastBlock;
+    }
+
+    bool isLastBlock() const {
+        return lastBlock;
+    }
+
 private:
     int64_t offset;
     bool corrupt;
     std::vector<DatanodeInfo> locs;
     std::vector<std::string> storageIDs;
     Token token;
+    bool lastBlock;
     // for ec block
     bool striped;
     std::vector<int8_t> indices;

--- a/src/server/LocatedBlocks.h
+++ b/src/server/LocatedBlocks.h
@@ -59,11 +59,15 @@ public:
 
     virtual const LocatedBlock * findBlock(int64_t position) = 0;
 
+    virtual const LocatedBlock * findBlock(int64_t position, int32_t & targetBlockIdx) = 0;
+
     virtual std::vector<LocatedBlock> & getBlocks() = 0;
 
     virtual shared_ptr<ECPolicy> getEcPolicy() const = 0;
 
     virtual void setEcPolicy(shared_ptr<ECPolicy> ecPolicy) = 0;
+
+    virtual void insertRange(int32_t blockIdx, std::vector<LocatedBlock> & newBlocks) = 0;
 };
 
 /**
@@ -106,6 +110,8 @@ public:
 
     const LocatedBlock * findBlock(int64_t position);
 
+    const LocatedBlock * findBlock(int64_t position, int32_t & targetBlockIdx);
+
     std::vector<LocatedBlock> & getBlocks() {
         return blocks;
     }
@@ -117,6 +123,11 @@ public:
     void setEcPolicy(shared_ptr<ECPolicy> policy) {
         ecPolicy = policy;
     }
+
+    void insertRange(int32_t blockIdx, std::vector<LocatedBlock> & newBlocks);
+
+    void addAll(std::vector<LocatedBlock> & oldBlocks, int32_t index, std::vector<LocatedBlock> & newBlocks,
+                int32_t start, int32_t end);
 
 private:
     bool lastBlockComplete;


### PR DESCRIPTION
Add positional read for client
1、Support localBlockReader and remoteBlockReader as same as stateful read.
2、Support concurrent positional read when multiple threads use a same inputStream.
3、Support stateful read and positional read by a same inputStream at the same time.