### PR TITLE
Fixes errors when compiling with gcc13

### DIFF
--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -1,6 +1,7 @@
 OPTION(ENABLE_COVERAGE "enable code coverage" OFF)
 OPTION(ENABLE_DEBUG "enable debug build" OFF)
 OPTION(ENABLE_SSE "enable SSE4.2 buildin function" ON)
+OPTION(ENABLE_LSX "enable Loongson LSX buildin function" OFF)
 OPTION(ENABLE_FRAME_POINTER "enable frame pointer on 64bit system with flag -fno-omit-frame-pointer, on 32bit system, it is always enabled" ON)
 OPTION(ENABLE_LIBCPP "using libc++ instead of libstdc++, only valid for clang compiler" OFF)
 OPTION(ENABLE_BOOST "using boost instead of native compiler c++0x support" OFF)
@@ -32,7 +33,11 @@ ENDIF(ENABLE_FRAME_POINTER STREQUAL ON)
 
 IF(ENABLE_SSE STREQUAL ON)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.2")
-ENDIF(ENABLE_SSE STREQUAL ON) 
+ENDIF(ENABLE_SSE STREQUAL ON)
+
+IF(ENABLE_LSX STREQUAL ON)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mlsx")
+ENDIF(ENABLE_LSX STREQUAL ON) 
 
 IF(NOT TEST_HDFS_PREFIX)
 SET(TEST_HDFS_PREFIX "./" CACHE STRING "default directory prefix used for test." FORCE)

--- a/bootstrap
+++ b/bootstrap
@@ -111,11 +111,17 @@ if [[ ! -x ${cmake} ]]; then
     die "cannot found cmake"
 fi
 
+if [[ `arch` = loongarch64 ]];then
+     enable_sse="OFF"
+     enable_lsx="ON"
+fi
+
 # Configure
 ${cmake} -DENABLE_DEBUG=${enable_build} -DCMAKE_INSTALL_PREFIX=${prefix_dirs} \
     -DCMAKE_C_COMPILER=${c_compiler} -DCMAKE_CXX_COMPILER=${cxx_compiler} \
     -DCMAKE_PREFIX_PATH=${dependency_dir} -DENABLE_BOOST=${enable_boost} \
     -DENABLE_COVERAGE=${enable_coverage} -DENABLE_LIBCPP=${enable_clang_lib} ${source_dir} \
+    -DENABLE_SSE=${enable_sse} -DENABLE_LSX=${enable_lsx} \
     || die "failed to configure the project"
 
 echo 'bootstrap success. Run "make" to build.'

--- a/src/client/ByteBuffer.h
+++ b/src/client/ByteBuffer.h
@@ -8,6 +8,7 @@
 #include <cstdlib>
 #include <string>
 #include <iostream>
+#include <cstdint>
 
 #include "Exception.h"
 #include "ExceptionInternal.h"

--- a/src/client/DataTransferProtocol.h
+++ b/src/client/DataTransferProtocol.h
@@ -32,6 +32,7 @@
 #include "server/DatanodeInfo.h"
 #include "server/ExtendedBlock.h"
 
+#include <cstdint>
 #include <vector>
 
 namespace Hdfs {

--- a/src/client/Permission.h
+++ b/src/client/Permission.h
@@ -28,6 +28,7 @@
 #ifndef _HDFS_LIBHDFS3_CLIENT_PERMISSION_H_
 #define _HDFS_LIBHDFS3_CLIENT_PERMISSION_H_
 
+#include <cstdint>
 #include <string>
 
 namespace Hdfs {

--- a/src/client/SystemECPolicies.cpp
+++ b/src/client/SystemECPolicies.cpp
@@ -19,6 +19,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <mutex>
 
 #include "Logger.h"
 #include "SystemECPolicies.h"

--- a/src/common/HWCrc32c.cpp
+++ b/src/common/HWCrc32c.cpp
@@ -34,7 +34,11 @@
 #include <cpuid.h>
 #endif
 
-#if ((defined(__X86__) || defined(__i386__) || defined(i386) || defined(_M_IX86) || defined(__386__) || defined(__x86_64__) || defined(_M_X64)))
+#if defined(__loongarch64)
+#include <larchintrin.h>
+#endif
+
+#if ((defined(__X86__) || defined(__i386__) || defined(i386) || defined(_M_IX86) || defined(__386__) || defined(__x86_64__) || defined(_M_X64) || defined(__loongarch64)))
 #if !defined(__SSE4_2__)
 
 namespace Hdfs {
@@ -42,23 +46,39 @@ namespace Internal {
 
 #if defined(__LP64__)
 static inline uint64_t _mm_crc32_u64(uint64_t crc, uint64_t value) {
+#if defined(__loongarch64)
+   crc = __crcc_w_d_w(value,crc);
+#else
     asm("crc32q %[value], %[crc]\n" : [crc] "+r"(crc) : [value] "rm"(value));
+#endif
     return crc;
 }
 #endif
 
 static inline uint32_t _mm_crc32_u16(uint32_t crc, uint16_t value) {
+#if defined(__loongarch64)
+    crc = __crcc_w_h_w(value,crc);
+#else
     asm("crc32w %[value], %[crc]\n" : [crc] "+r"(crc) : [value] "rm"(value));
+#endif
     return crc;
 }
 
 static inline uint32_t _mm_crc32_u32(uint32_t crc, uint64_t value) {
+#if defined(__loongarch64)
+    crc = __crcc_w_w_w(value,crc);
+#else
     asm("crc32l %[value], %[crc]\n" : [crc] "+r"(crc) : [value] "rm"(value));
+#endif
     return crc;
 }
 
 static inline uint32_t _mm_crc32_u8(uint32_t crc, uint8_t value) {
+#if defined(__loongarch64)
+    crc = __crcc_w_b_w(value,crc);
+#else
     asm("crc32b %[value], %[crc]\n" : [crc] "+r"(crc) : [value] "rm"(value));
+#endif
     return crc;
 }
 
@@ -86,7 +106,7 @@ bool HWCrc32c::available() {
      */
     __get_cpuid(1, &eax, &ebx, &ecx, &edx);
     return (ecx & (1 << 20)) != 0;
-#elif ((defined(__arm__) || defined(__aarch64__)))
+#elif ((defined(__arm__) || defined(__aarch64__) || defined(__loongarch64)))
     return true;    
 #else
     return false;

--- a/src/common/MappedFileWrapper.cpp
+++ b/src/common/MappedFileWrapper.cpp
@@ -31,6 +31,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <cstdint>
 #include <limits>
 #include <string>
 #include <sstream>

--- a/src/rpc/RpcServerInfo.h
+++ b/src/rpc/RpcServerInfo.h
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <sstream>
+#include <cstdint>
 
 namespace Hdfs {
 namespace Internal {

--- a/src/server/DatanodeInfo.h
+++ b/src/server/DatanodeInfo.h
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <sstream>
+#include <cstdint>
 
 namespace Hdfs {
 namespace Internal {


### PR DESCRIPTION
errors info when compiling with gcc13

`
/home/loongson/libhdfs3/src/client/ByteBuffer.h:221:9: error: ‘uint32_t’ was not declared in this scope
  221 |         uint32_t s = sizeof(data);

  /home/loongson/libhdfs3/src/client/SystemECPolicies.cpp:62:10: error: ‘unique_lock’ is not a member of ‘std’
`

`
   62 |     std::unique_lock<std::shared_mutex> lock(mutex);
      |          ^~~~~~~~~~~
/home/loongson/libhdfs3/src/client/SystemECPolicies.cpp:25:1: note: ‘std::unique_lock’ is defined in header ‘<mutex>’; did you forget to ‘#include <mutex>’?
   24 | #include "SystemECPolicies.h"
  +++ |+#include <mutex>
`