### PR TITLE
Throw exception when block can't be found in function fetchBlockAt

### DIFF
--- a/src/server/LocatedBlocks.cpp
+++ b/src/server/LocatedBlocks.cpp
@@ -120,7 +120,7 @@ void LocatedBlocksImpl::addAll(std::vector<LocatedBlock> & oldBlocks, int32_t in
         oldBlocks[i + shiftSize] = oldBlocks[i];
     }
     for (int32_t i = 0; i < shiftSize; ++i) {
-        oldBlocks[index + i] = newBlocks[i];
+        oldBlocks[index + i] = newBlocks[start + i];
     }
 }
 


### PR DESCRIPTION
1、add assert when can't find block in function fetchBlockAt.
2、fix two bugs in [last PR](https://github.com/ClickHouse/libhdfs3/pull/53).