### PR TITLE
Missing includes with libstdc++ 13.2.0

### DIFF
--- a/src/client/ByteBuffer.h
+++ b/src/client/ByteBuffer.h
@@ -5,6 +5,7 @@
 #ifndef _HDFS_LIBHDFS3_CLIENT_BYTEBUFFER_H_
 #define _HDFS_LIBHDFS3_CLIENT_BYTEBUFFER_H_
 
+#include <cstdint>
 #include <cstdlib>
 #include <string>
 #include <iostream>

--- a/src/client/Permission.h
+++ b/src/client/Permission.h
@@ -28,6 +28,7 @@
 #ifndef _HDFS_LIBHDFS3_CLIENT_PERMISSION_H_
 #define _HDFS_LIBHDFS3_CLIENT_PERMISSION_H_
 
+#include <cstdint>
 #include <string>
 
 namespace Hdfs {

--- a/src/client/SystemECPolicies.cpp
+++ b/src/client/SystemECPolicies.cpp
@@ -20,6 +20,8 @@
  * limitations under the License.
  */
 
+#include <mutex>
+
 #include "Logger.h"
 #include "SystemECPolicies.h"
 

--- a/src/common/MappedFileWrapper.cpp
+++ b/src/common/MappedFileWrapper.cpp
@@ -31,6 +31,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <cstdint>
 #include <limits>
 #include <string>
 #include <sstream>

--- a/src/rpc/RpcServerInfo.h
+++ b/src/rpc/RpcServerInfo.h
@@ -30,6 +30,7 @@
 
 #include "Hash.h"
 
+#include <cstdint>
 #include <string>
 #include <sstream>
 

--- a/src/server/DatanodeInfo.h
+++ b/src/server/DatanodeInfo.h
@@ -28,6 +28,7 @@
 #ifndef _HDFS_LIBHDFS3_SERVER_DATANODEINFO_H_
 #define _HDFS_LIBHDFS3_SERVER_DATANODEINFO_H_
 
+#include <cstdint>
 #include <string>
 #include <sstream>
 


### PR DESCRIPTION
To compile this library against libstdc++ 13.2.0 (the default in Ubuntu 24.04), some additional includes from the standard library are required. This pull request adds those missing includes.