### PR TITLE
fix compile failed caused by sse4_2

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -66,6 +66,7 @@ build_type="Release"
 enable_boost="OFF"
 enable_coverage="OFF"
 enable_clang_lib="OFF"
+enable_sse="ON"
 while test $# != 0; do
     case "$1" in
     --prefix=*) dir=`arg "$1"`


### PR DESCRIPTION
CentOS-7
gcc 11

![image](https://github.com/ClickHouse/libhdfs3/assets/25115709/c7dbbe9c-e23d-4ba5-a9eb-3f27c4258696)

![image](https://github.com/ClickHouse/libhdfs3/assets/25115709/21bb1c9f-875e-48b1-a939-fff7f7b3d6dc)
