### PR TITLE
Disable crc_pcl in IntelAsmCrc32c.cpp to support macOS compilation with HDFS3.

### DIFF
--- a/src/client/LocalBlockReader.cpp
+++ b/src/client/LocalBlockReader.cpp
@@ -84,7 +84,7 @@ LocalBlockReader::LocalBlockReader(const shared_ptr<ReadShortCircuitInfo>& info,
 
         case ChecksumTypeProto::CHECKSUM_CRC32:
         case ChecksumTypeProto::CHECKSUM_CRC32C:
-#if defined(__SSE4_2__) && defined(__LP64__)
+#if defined(__SSE4_2__) && defined(__LP64__) &&!defined(__APPLE__)
             checksum = std::make_shared<IntelAsmCrc32c>();
 #else
 #if !(((defined(__PPC64__) || defined(__powerpc64__)) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)) || (defined(__s390x__)))

--- a/src/client/OutputStreamImpl.cpp
+++ b/src/client/OutputStreamImpl.cpp
@@ -52,7 +52,7 @@ OutputStreamImpl::OutputStreamImpl() :
         0), chunksPerPacket(0), closeTimeout(0), heartBeatInterval(0), packetSize(0), position(
             0), replication(0), blockSize(0), bytesWritten(0), cursor(0), lastFlushed(
                 0), nextSeqNo(0) {
-#if defined(__SSE4_2__) && defined(__LP64__)
+#if defined(__SSE4_2__) && defined(__LP64__) &&!defined(__APPLE__)
     checksum = std::make_shared<IntelAsmCrc32c>();
 #else
 #if !(((defined(__PPC64__) || defined(__powerpc64__)) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)) || (defined(__s390x__)))

--- a/src/client/RemoteBlockReader.cpp
+++ b/src/client/RemoteBlockReader.cpp
@@ -160,7 +160,7 @@ void RemoteBlockReader::checkResponse() {
         break;
 
     case ChecksumTypeProto::CHECKSUM_CRC32C:
-#if defined(__SSE4_2__) && defined(__LP64__)
+#if defined(__SSE4_2__) && defined(__LP64__) &&!defined(__APPLE__)
         checksum = std::make_shared<IntelAsmCrc32c>();
 #else
 #if !(((defined(__PPC64__) || defined(__powerpc64__)) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)) || (defined(__s390x__)))

--- a/src/common/IntelAsmCrc32c.cpp
+++ b/src/common/IntelAsmCrc32c.cpp
@@ -29,7 +29,7 @@
 #include <cstdlib>
 #include "IntelAsmCrc32c.h"
 
-#if defined(__SSE4_2__) && defined(__LP64__)
+#if defined(__SSE4_2__) && defined(__LP64__) && !defined(__APPLE__)
 
 extern "C" unsigned int crc_pcl ( unsigned char * buffer, int len, unsigned int crc_init );
 

--- a/src/common/IntelAsmCrc32c.h
+++ b/src/common/IntelAsmCrc32c.h
@@ -28,7 +28,7 @@
 #ifndef _HDFS_LIBHDFS3_COMMON_INTELASMCRC32C_H_
 #define _HDFS_LIBHDFS3_COMMON_INTELASMCRC32C_H_
 
-#if defined(__SSE4_2__) && defined(__LP64__)
+#if defined(__SSE4_2__) && defined(__LP64__) &&!defined(__APPLE__)
 
 #include "Checksum.h"
 

--- a/src/common/perf_checksum.cpp
+++ b/src/common/perf_checksum.cpp
@@ -34,7 +34,7 @@ static inline void benchmark(const std::shared_ptr<Checksum> & checksum, const v
 int main()
 {
     std::map<std::string, std::shared_ptr<Checksum>> checksums = {
-#if defined(__SSE4_2__) && defined(__LP64__)
+#if defined(__SSE4_2__) && defined(__LP64__) &&!defined(__APPLE__)
         {"HWCrc32c", std::make_shared<HWCrc32c>()},
         {"IntelAsmCrc32c", std::make_shared<IntelAsmCrc32c>()},
 #endif


### PR DESCRIPTION
https://github.com/ClickHouse/ClickHouse/issues/41963